### PR TITLE
Add simple class editor and viewer

### DIFF
--- a/magicmirror-node/public/editor-kelas.html
+++ b/magicmirror-node/public/editor-kelas.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Editor Kelas</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&family=Fredoka:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/grapesjs@0.21.5/dist/css/grapes.min.css">
+  <link rel="stylesheet" href="editor-style.css">
+</head>
+<body>
+  <div id="sidebar">
+    <h2>Toolbox</h2>
+    <div id="actions">
+      <button id="preview-btn">Preview</button>
+      <button id="save-btn">Simpan Layout</button>
+      <button id="load-btn">Load Layout</button>
+    </div>
+    <div id="blocks"></div>
+  </div>
+  <div id="canvas">
+    <div id="gjs"></div>
+  </div>
+  <script src="https://unpkg.com/grapesjs@0.21.5/dist/grapes.min.js"></script>
+  <script src="editor-script.js"></script>
+</body>
+</html>

--- a/magicmirror-node/public/editor-script.js
+++ b/magicmirror-node/public/editor-script.js
@@ -1,0 +1,74 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const classId = params.get('id') || 'default';
+
+  const editor = grapesjs.init({
+    container: '#gjs',
+    height: '100%',
+    storageManager: false,
+    blockManager: { appendTo: '#blocks' },
+    fromElement: false,
+    panels: { defaults: [] }
+  });
+
+  const bm = editor.BlockManager;
+  bm.add('text', {
+    label: 'Teks Modul',
+    content: '<div class="text">Edit teks modul...</div>'
+  });
+  bm.add('image', {
+    label: 'Gambar',
+    content: '<img src="https://via.placeholder.com/400x200" alt="gambar" />'
+  });
+  bm.add('video', {
+    label: 'Video',
+    content: '<div class="video"><iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe></div>'
+  });
+  bm.add('quiz', {
+    label: 'Quiz',
+    content: `<div class="quiz">
+      <p>Pertanyaan di sini?</p>
+      <label><input type="radio" name="q">Jawaban 1</label><br/>
+      <label><input type="radio" name="q">Jawaban 2</label><br/>
+      <label><input type="radio" name="q">Jawaban 3</label>
+    </div>`
+  });
+  bm.add('lab', {
+    label: 'Lab Coding',
+    content: '<div class="lab-coding"><textarea>// kode di sini</textarea></div>'
+  });
+
+  function saveLayout() {
+    const data = {
+      html: editor.getHtml(),
+      css: editor.getCss()
+    };
+    localStorage.setItem('layout_kelas_' + classId, JSON.stringify(data));
+    alert('Layout disimpan');
+  }
+
+  function loadLayout() {
+    const raw = localStorage.getItem('layout_kelas_' + classId);
+    if (raw) {
+      const data = JSON.parse(raw);
+      editor.setComponents(data.html);
+      editor.setStyle(data.css);
+    } else {
+      alert('Belum ada layout tersimpan');
+    }
+  }
+
+  function previewLayout() {
+    const html = `<style>${editor.getCss()}</style>${editor.getHtml()}`;
+    const w = window.open();
+    w.document.write(html);
+    w.document.close();
+  }
+
+  document.getElementById('save-btn').addEventListener('click', saveLayout);
+  document.getElementById('load-btn').addEventListener('click', loadLayout);
+  document.getElementById('preview-btn').addEventListener('click', previewLayout);
+
+  // Auto load existing layout on start
+  loadLayout();
+});

--- a/magicmirror-node/public/editor-style.css
+++ b/magicmirror-node/public/editor-style.css
@@ -1,0 +1,49 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  background-color: #f0f7ff;
+  display: flex;
+  height: 100vh;
+}
+#sidebar {
+  width: 240px;
+  background: #d0e8ff;
+  padding: 20px;
+  box-shadow: 2px 0 8px rgba(0,0,0,0.1);
+  overflow-y: auto;
+}
+#sidebar h2 {
+  font-family: 'Fredoka', sans-serif;
+  margin-top: 0;
+}
+#actions {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: none;
+  background: #4ea1ff;
+  color: white;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background 0.2s;
+}
+button:hover {
+  background: #3b8ce6;
+}
+#canvas {
+  flex: 1;
+}
+.quiz {
+  border: 1px solid #b6d4ff;
+  padding: 10px;
+  border-radius: 8px;
+}
+.lab-coding textarea {
+  width: 100%;
+  min-height: 120px;
+}

--- a/magicmirror-node/public/viewer-kelas.html
+++ b/magicmirror-node/public/viewer-kelas.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Viewer Kelas</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&family=Fredoka:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Poppins', sans-serif; margin: 0; background: #f5faff; padding: 20px; }
+  </style>
+</head>
+<body>
+  <div id="output">Memuat...</div>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id') || 'default';
+    const data = localStorage.getItem('layout_kelas_' + id);
+    if (data) {
+      const layout = JSON.parse(data);
+      document.getElementById('output').innerHTML = `<style>${layout.css}</style>${layout.html}`;
+    } else {
+      document.getElementById('output').innerText = 'Layout tidak ditemukan';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `editor-kelas.html` with a GrapesJS-based drag-and-drop interface
- add editor styling and scripting
- allow saving/loading class layouts from `localStorage`
- add `viewer-kelas.html` to render saved layouts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845890ee0c08325be8b1c55a1f9b4bb