### PR TITLE
Fix turtle lab output

### DIFF
--- a/magicmirror-node/public/labs/lab_turtle.html
+++ b/magicmirror-node/public/labs/lab_turtle.html
@@ -10,6 +10,7 @@
     textarea {width:100%; height:150px; border-radius:8px; padding:10px; font-size:16px;}
     button {margin-top:10px; padding:10px 16px; background:#34d399; color:#fff; border:none; border-radius:8px; cursor:pointer;}
     #output {border:1px solid #ccc; margin-top:20px; width:100%; height:300px;}
+    #status {margin-top:10px; font-weight:bold;}
   </style>
 </head>
 <body>
@@ -22,6 +23,7 @@ t.right(90)
 t.forward(100)
 t.right(90)</textarea>
   <button onclick="runTurtle()">Run</button>
+  <div id="status"></div>
   <div id="output"><canvas id="turtle-canvas" width="400" height="300" style="border:1px solid #000;"></canvas></div>
 
   <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>

--- a/magicmirror-node/public/labs/lab_turtle.js
+++ b/magicmirror-node/public/labs/lab_turtle.js
@@ -28,8 +28,8 @@ function drawLine(x1, y1, x2, y2) {
 }
 
 async function runTurtle() {
-  const output = document.getElementById("output");
-  output.textContent = "Menjalankan...";
+  const status = document.getElementById("status");
+  status.textContent = "Menjalankan...";
   const code = document.getElementById("code").value;
 
   await pyReady;
@@ -63,8 +63,9 @@ t = SimTurtle()
   try {
     clearCanvas();
     await pyodide.runPythonAsync(script, { globals: namespace });
-    output.textContent = "✅ Selesai!";
+    status.textContent = "✅ Selesai!";
+    namespace.destroy && namespace.destroy();
   } catch (err) {
-    output.textContent = "❌ Error: " + err;
+    status.textContent = "❌ Error: " + err;
   }
 }


### PR DESCRIPTION
## Summary
- fix bug where Turtle canvas was removed by status text
- use dedicated status div in Turtle lab
- cleanup pyodide namespace

## Testing
- `node -c magicmirror-node/public/labs/lab_turtle.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845cab7ddd88325aeac7cf201da6a35