### PR TITLE
Add whiteboard and fix typing panels

### DIFF
--- a/magicmirror-node/public/elearn/M1L2.html
+++ b/magicmirror-node/public/elearn/M1L2.html
@@ -1,0 +1,259 @@
+<link rel="stylesheet" href="presetvs.css" />
+<script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
+<script src="presetvs.js"></script>
+<style>
+  body {
+    font-family: 'Fredoka', sans-serif;
+    margin: 0;
+    background: #f0f7ff;
+    color: #333;
+  }
+  .header {
+    text-align: center;
+    padding: 20px;
+    background: #4f46e5;
+    color: #fff;
+  }
+  .header h1 {
+    margin-bottom: 10px;
+    font-size: 2.2rem;
+  }
+  .header p {
+    margin-bottom: 20px;
+  }
+  .progress-container {
+    margin-top: 20px;
+    width: 80%;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .progress-bar {
+    height: 12px;
+    background: #fff;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .progress {
+    width: 0%;
+    height: 100%;
+    background: #facc15;
+  }
+  .back-btn {
+    display: inline-block;
+    margin-top: 8px;
+    color: #fff;
+    background: #22c55e;
+    padding: 6px 12px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: bold;
+  }
+  .container {
+    display: flex;
+    padding: 20px;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .sidebar {
+    flex: 1 1 180px;
+    max-width: 200px;
+    background: #fde68a;
+    padding: 20px;
+    border-radius: 20px;
+  }
+  .sidebar ul {
+    list-style: none;
+    padding: 0;
+  }
+  .sidebar li {
+    margin-bottom: 10px;
+    background: #fcd34d;
+    padding: 8px 12px;
+    border-radius: 10px;
+    cursor: pointer;
+  }
+  .sidebar li.active {
+    background: #fbbf24;
+  }
+  .main {
+    flex: 3 1 300px;
+    background: #fff;
+    padding: 20px;
+    border-radius: 20px;
+  }
+  .lab-column {
+    flex: 1 1 260px;
+    background: #111827;
+    padding: 20px;
+    border-radius: 20px;
+    color: #a7f3d0;
+    min-width: 260px;
+  }
+  .whiteboard-container {
+    margin-top: 1rem;
+    text-align: center;
+  }
+  #whiteboardCanvas {
+    border: 1px solid #ccc;
+    width: 100%;
+    height: 300px;
+    display: none;
+    touch-action: none;
+    background: #fff;
+  }
+  .step-content {
+    display: none;
+    background: #fff;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 3px 8px rgba(0,0,0,0.1);
+    margin-bottom: 20px;
+  }
+  .step-content.active { display: block; }
+  .nav-controls { text-align: center; margin-top: 20px; }
+</style>
+
+<div class="header">
+  <h1>Modul 1 - Lesson 2: Variabel</h1>
+  <p>Memahami Variabel dengan cara seru</p>
+  <div class="progress-container">
+    <div class="progress-bar"><div class="progress" id="progressBar"></div></div>
+  </div>
+  <div style="margin-top:10px;">
+    <a href="/elearn/modul1.html" class="back-btn">⟵ Kembali ke Modul</a>
+  </div>
+</div>
+
+<div class="container">
+  <div class="sidebar">
+    <ul id="lesson-nav">
+      <li data-step="1" class="active">1. Warm-Up</li>
+      <li data-step="3">2. Praktik Pertama</li>
+      <li data-step="6">3. Teori Tipe Data</li>
+      <li data-step="10">4. Eksperimen</li>
+      <li data-step="13">5. Quiz</li>
+      <li data-step="15">6. Wrap-Up</li>
+    </ul>
+  </div>
+  <div class="main">
+    <div id="panel-1" class="step-content">
+      <h2>Kotak Rahasia</h2>
+      <p>Bayangkan kamu punya kotak rahasia. Kamu bisa memasukkan angka, nama, atau benda ke dalamnya.</p>
+    </div>
+    <div id="panel-2" class="step-content">
+      <h2>Apa itu Variabel?</h2>
+      <p>Di Python, kotak ajaib itu disebut <em>variabel</em>. Ia menyimpan apa pun yang kamu masukkan.</p>
+    </div>
+    <div id="panel-3" class="step-content">
+      <h2>Membuat Variabel Pertama</h2>
+      <p>Yuk coba menulis kode sederhana.</p>
+    </div>
+    <div id="panel-4" class="step-content">
+      <div class="typingBox-vscode" data-hint="nama = &quot;Nina&quot;&#10;umur = 10&#10;print(nama)&#10;print(umur)"></div>
+    </div>
+    <div id="panel-5" class="step-content">
+      <h2>Apa Arti Tanda = ?</h2>
+      <p>Tanda sama dengan berarti kita menyimpan nilai ke dalam variabel.</p>
+    </div>
+    <div id="panel-6" class="step-content">
+      <h2>Jenis Isi Kotak</h2>
+      <p>Variabel bisa berisi teks, angka bulat, atau angka desimal.</p>
+    </div>
+    <div id="panel-7" class="step-content">
+      <h2>Nama Tipe Data</h2>
+      <p>Teks disebut <code>str</code>, angka bulat <code>int</code>, dan angka desimal <code>float</code>.</p>
+    </div>
+    <div id="panel-8" class="step-content">
+      <div class="typingBox-vscode" data-hint="tinggi = 135.5&#10;print(tinggi)"></div>
+    </div>
+    <div id="panel-9" class="step-content">
+      <h2>Pilih Nama yang Jelas</h2>
+      <p>Gunakan nama variabel yang mudah dibaca agar tidak membingungkan.</p>
+    </div>
+    <div id="panel-10" class="step-content">
+      <h2>Ubah Isi Variabel</h2>
+      <p>Coba ganti isi variabel dan lihat hasilnya.</p>
+    </div>
+    <div id="panel-11" class="step-content">
+      <div class="typingBox-vscode" data-hint="buah = &quot;Apel&quot;&#10;print(buah)&#10;buah = &quot;Jeruk&quot;&#10;print(buah)"></div>
+    </div>
+    <div id="panel-12" class="step-content">
+      <h2>Bisa Berubah-ubah</h2>
+      <p>Lihat? Isi variabel bisa berubah kapan saja sesuai perintahmu.</p>
+    </div>
+    <div id="panel-13" class="step-content">
+      <h2>Quiz: Apa Hasilnya?</h2>
+      <pre><code>warna = "Biru"
+warna = "Merah"
+print(warna)</code></pre>
+    </div>
+    <div id="panel-14" class="step-content">
+      <h2>Pilih Jawaban Benar</h2>
+      <ol>
+        <li>Apa isi variabel <code>warna</code> yang dicetak?</li>
+        <ul><li>a) Biru</li><li>b) Merah ✅</li></ul>
+        <li>Manakah pernyataan benar tentang variabel?</li>
+        <ul><li>a) Tidak bisa diubah</li><li>b) Harus huruf besar</li><li>c) Menyimpan nilai yang bisa digunakan lagi ✅</li></ul>
+      </ol>
+    </div>
+    <div id="panel-15" class="step-content">
+      <h2>Wrap-Up</h2>
+      <p>Variabel itu seperti kotak ajaib. Gunakan tanda <code>=</code> untuk menyimpan dan cetak dengan <code>print()</code>. Lesson berikutnya kita belajar bermain dengan teks. Sekarang kamu punya kotak sakti di Python!</p>
+    </div>
+    <div class="nav-controls">
+      <button onclick="prevPanel()">⟵ Sebelumnya</button>
+      <span id="indicator"></span>
+      <button onclick="nextPanel()">Selanjutnya ⟶</button>
+    </div>
+  </div>
+  <div class="lab-column">
+    <div class="whiteboard-container">
+      <button id="toggleWhiteboard">Tampilkan Whiteboard</button>
+      <button id="clearWhiteboard">Clear</button>
+      <canvas id="whiteboardCanvas"></canvas>
+    </div>
+  </div>
+</div>
+
+<script>
+  let currentPanel = 1;
+  const totalPanels = 15;
+  function showPanel(n) {
+    if (n < 1 || n > totalPanels) return;
+    document.querySelectorAll('.step-content').forEach(el => el.classList.remove('active'));
+    const panel = document.getElementById('panel-' + n);
+    if (panel) panel.classList.add('active');
+    currentPanel = n;
+    updateIndicator();
+  }
+  function nextPanel() { if (currentPanel < totalPanels) showPanel(currentPanel + 1); }
+  function prevPanel() { if (currentPanel > 1) showPanel(currentPanel - 1); }
+  function updateIndicator() { document.getElementById('indicator').textContent = 'Slide ' + currentPanel + ' / ' + totalPanels; }
+  document.getElementById('lesson-nav').addEventListener('click', function(e) {
+    if(e.target.matches('li[data-step]')) {
+      document.querySelectorAll('#lesson-nav li').forEach(li => li.classList.remove('active'));
+      e.target.classList.add('active');
+      showPanel(Number(e.target.getAttribute('data-step')));
+    }
+  });
+  document.addEventListener('DOMContentLoaded', () => showPanel(1));
+</script>
+<!-- Firebase and Whiteboard -->
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js"></script>
+<script src="whiteboard.js"></script>
+<script>
+  const firebaseConfig = {
+    apiKey: "AIzaSyBVO4ajDwkbcTGL33SVMxIoev4veB8itgI",
+    authDomain: "queens-academy-icoding.firebaseapp.com",
+    projectId: "queens-academy-icoding",
+    storageBucket: "queens-academy-icoding.appspot.com",
+    messagingSenderId: "1048549258959",
+    appId: "1:1048549258959:web:f8dc1c104bb170d7ff69ba",
+  };
+  firebase.initializeApp(firebaseConfig);
+  window.kelasId = 'demo';
+  window.lessonId = 'M1L2';
+  initWhiteboard();
+</script>

--- a/magicmirror-node/public/elearn/presetvs.js
+++ b/magicmirror-node/public/elearn/presetvs.js
@@ -8,6 +8,7 @@ if (typeof window.pyodide === 'undefined') {
   loadPyodideAndPackages();
 }
 console.log("✅ presetvs.js loaded");
+window.activeTypingBox = null;
 function setupVscodeTypingBox(container) {
   console.log("🔧 setupVscodeTypingBox dipanggil untuk:", container);
   const rawHint = container.getAttribute('data-hint') || '';
@@ -83,8 +84,14 @@ function setupVscodeTypingBox(container) {
   }
 
   container.classList.add('initialized');
+  container.setAttribute('tabindex', '0');
+  container.addEventListener('click', () => {
+    window.activeTypingBox = container;
+    container.focus();
+  });
 
-  document.addEventListener('keydown', (e) => {
+  container.addEventListener('keydown', (e) => {
+    if (window.activeTypingBox !== container) return;
     if (container._lineIndex < 0 || container._lineIndex >= lines.length) return;
     const line = lines[container._lineIndex];
 
@@ -167,7 +174,7 @@ function setupVscodeTypingBox(container) {
     const outputEl = container.querySelector(".code-output");
     if (outputEl) outputEl.textContent = lines;
   };
-  document.addEventListener("keydown", updateCodeOutput);
+  container.addEventListener("keydown", updateCodeOutput);
 
   renderCode();
 }


### PR DESCRIPTION
## Summary
- refine the interactive lesson `M1L2.html`
  - remove unused run buttons
  - add back-to-module link
  - embed Firebase whiteboard
- isolate editors inside `presetvs.js` so typing only affects the focused panel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d4b1b208832591ec86682c00193e