### PR TITLE
Add Game & Robotic Playground

### DIFF
--- a/elearn/playground-script.js
+++ b/elearn/playground-script.js
@@ -1,0 +1,145 @@
+let pyodideReadyPromise = loadPyodide();
+let currentLab = '';
+const badges = JSON.parse(localStorage.getItem('badges') || '[]');
+const badgeIcons = {
+  game: 'sports_esports',
+  robot: 'smart_toy',
+  python: 'code',
+  puzzle: 'extension'
+};
+
+function addBadge(name) {
+  if (!badges.includes(name)) {
+    badges.push(name);
+    localStorage.setItem('badges', JSON.stringify(badges));
+    renderBadges();
+  }
+}
+
+function renderBadges() {
+  const container = document.getElementById('badges');
+  container.innerHTML = badges
+    .map(b => `<span class="material-icons badge">${badgeIcons[b] || 'emoji_events'}</span>`) 
+    .join('');
+}
+renderBadges();
+
+document.querySelectorAll('.lab-btn').forEach(btn => {
+  btn.addEventListener('click', () => loadLab(btn.dataset.lab));
+});
+
+document.getElementById('back-btn').addEventListener('click', () => {
+  window.location.href = '../index.html';
+});
+
+async function loadLab(name) {
+  currentLab = name;
+  const container = document.getElementById('lab-content');
+  container.innerHTML = '';
+  switch(name) {
+    case 'game-maker':
+      loadGameMaker(container); break;
+    case 'robot-sim':
+      loadRobotSim(container); break;
+    case 'python-editor':
+      loadPythonEditor(container); break;
+    case 'puzzle-coding':
+      loadPuzzle(container); break;
+  }
+}
+
+function loadGameMaker(el) {
+  const workspaceDiv = document.createElement('div');
+  workspaceDiv.id = 'blockly-game';
+  workspaceDiv.style.height = '300px';
+  el.appendChild(workspaceDiv);
+  const canvas = document.createElement('canvas');
+  canvas.id = 'game-canvas';
+  canvas.width = 400;
+  canvas.height = 300;
+  canvas.style.border = '1px solid #fff';
+  el.appendChild(canvas);
+  const btnRun = document.createElement('button'); btnRun.textContent='Mainkan';
+  const btnReset = document.createElement('button'); btnReset.textContent='Reset';
+  const btnSave = document.createElement('button'); btnSave.textContent='Simpan';
+  el.append(btnRun, btnReset, btnSave);
+  const workspace = Blockly.inject('blockly-game', {toolbox: `<xml><block type="controls_repeat_ext"></block><block type="controls_if"></block><block type="move"></block><block type="jump"></block><block type="collect"></block></xml>`});
+  Blockly.defineBlocksWithJsonArray([
+    {"type":"move","message0":"move","previousStatement":null,"nextStatement":null,"colour":120},
+    {"type":"jump","message0":"jump","previousStatement":null,"nextStatement":null,"colour":120},
+    {"type":"collect","message0":"collect","previousStatement":null,"nextStatement":null,"colour":120}
+  ]);
+  btnRun.onclick = () => {
+    addBadge('game');
+    alert('Game dijalankan!');
+  };
+  btnReset.onclick = () => workspace.clear();
+  btnSave.onclick = () => localStorage.setItem('gameBlocks', Blockly.serialization.workspaces.save(workspace));
+}
+
+function loadRobotSim(el) {
+  el.innerHTML = `<textarea id="robot-code" rows="5" cols="40">move_forward()\nturn_left()\nmove_forward()</textarea><br><button id="run-robot">Jalankan</button><button id="reset-robot">Ulangi</button><canvas id="robot-canvas" width="400" height="400" style="border:1px solid #fff"></canvas>`;
+  let x=0,y=0,dir=0; // dir:0 east,1 south,2 west,3 north
+  const ctx = document.getElementById('robot-canvas').getContext('2d');
+  const robotImg = new Image();
+  robotImg.src = 'https://upload.wikimedia.org/wikipedia/commons/3/3b/Robot_cartoon_05.svg';
+  robotImg.onload = draw;
+  function draw(){
+    ctx.clearRect(0,0,400,400);
+    ctx.strokeStyle='#555';
+    for(let i=0;i<=10;i++){
+      ctx.beginPath();
+      ctx.moveTo(i*40,0);ctx.lineTo(i*40,400);ctx.stroke();
+      ctx.beginPath();ctx.moveTo(0,i*40);ctx.lineTo(400,i*40);ctx.stroke();
+    }
+    ctx.drawImage(robotImg,x*40,y*40,40,40);
+  }
+  document.getElementById('run-robot').onclick = async () => {
+    const code=document.getElementById('robot-code').value;
+    const py=`x=${x}\ny=${y}\ndir=${dir}\n`+
+`def move_forward():\n  global x,y,dir\n  if dir==0:x+=1\n  elif dir==1:y+=1\n  elif dir==2:x-=1\n  else:y-=1\n`+
+`def turn_left():\n  global dir\n  dir=(dir-1)%4\n`+
+`def turn_right():\n  global dir\n  dir=(dir+1)%4\n`+code+`\nresult=(x,y,dir)`;
+    let pyodide=await pyodideReadyPromise;
+    await pyodide.runPythonAsync(py);
+    x=pyodide.globals.get('x');
+    y=pyodide.globals.get('y');
+    dir=pyodide.globals.get('dir');
+    draw();
+    addBadge('robot');
+  };
+  document.getElementById('reset-robot').onclick=()=>{x=0;y=0;dir=0;draw();};
+  draw();
+}
+
+function loadPythonEditor(el){
+  el.innerHTML=`<textarea id="py-editor" rows="10" cols="60">print(\"Halo Dunia!\")</textarea><br><button id="run-py">Jalankan</button><pre id="py-output"></pre>`;
+  document.getElementById('run-py').onclick=async()=>{
+    let pyodide=await pyodideReadyPromise;
+    let code=document.getElementById('py-editor').value;
+    try{
+      let result=await pyodide.runPythonAsync(code);
+      document.getElementById('py-output').textContent=result||'';
+      addBadge('python');
+    }catch(e){
+      document.getElementById('py-output').textContent=e;
+    }
+  };
+}
+
+function loadPuzzle(el){
+  const workspaceDiv=document.createElement('div');
+  workspaceDiv.id='blockly-puzzle';
+  workspaceDiv.style.height='300px';
+  el.appendChild(workspaceDiv);
+  const toolbox=`<xml><block type="move_forward"></block><block type="turn_left"></block><block type="turn_right"></block><block type="controls_repeat_ext"></block></xml>`;
+  Blockly.defineBlocksWithJsonArray([
+    {"type":"move_forward","message0":"move forward","previousStatement":null,"nextStatement":null,"colour":60},
+    {"type":"turn_left","message0":"turn left","previousStatement":null,"nextStatement":null,"colour":60},
+    {"type":"turn_right","message0":"turn right","previousStatement":null,"nextStatement":null,"colour":60}
+  ]);
+  const workspace=Blockly.inject('blockly-puzzle',{toolbox});
+  const btn=document.createElement('button');btn.textContent='Selesai';
+  el.appendChild(btn);
+  btn.onclick=()=>{addBadge('puzzle');alert('Selamat!');};
+}

--- a/elearn/playground-style.css
+++ b/elearn/playground-style.css
@@ -1,0 +1,58 @@
+body {
+  display: flex;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #1e1e2f;
+  color: #fff;
+}
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #29294d;
+  padding: 10px;
+  text-align: center;
+  z-index: 1000;
+}
+header h1 {
+  margin: 0;
+  font-size: 24px;
+}
+#back-btn {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+}
+#sidebar {
+  margin-top: 60px;
+  width: 200px;
+  background: #2d2d50;
+  padding: 20px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.lab-btn {
+  padding: 10px;
+  background: #4b4ba8;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+  font-size: 16px;
+}
+.lab-btn:hover {
+  background: #6a6ad6;
+}
+#lab-content {
+  margin-top: 60px;
+  flex: 1;
+  padding: 20px;
+}
+.badge {
+  font-size: 32px;
+  margin: 5px;
+  color: gold;
+}
+

--- a/elearn/playground.html
+++ b/elearn/playground.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Game & Robotic Playground</title>
+  <link rel="stylesheet" href="playground-style.css">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
+</head>
+<body>
+  <header>
+    <h1>🏕️ Game & Robotic Playground</h1>
+    <button id="back-btn">&lt;&lt; Kembali ke Dashboard</button>
+  </header>
+  <aside id="sidebar">
+    <button class="lab-btn" data-lab="game-maker">Game Maker Kids</button>
+    <button class="lab-btn" data-lab="robot-sim">Simulasi Robotik</button>
+    <button class="lab-btn" data-lab="python-editor">Python Editor</button>
+    <button class="lab-btn" data-lab="puzzle-coding">Puzzle Coding</button>
+    <div id="badges"></div>
+  </aside>
+  <main id="lab-content"></main>
+  <script src="playground-script.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- create new interactive playground page
- add futuristic playful styling and controls
- implement basic Blockly and Pyodide examples for four labs
- store user progress badges in localStorage
- use Material icons to avoid binary files

## Testing
- `npm test` within firebase-upload-backend (fails: no test specified)
- `npm test` within magicmirror-node (fails: missing script)
- `python3 -m unittest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6847550084ec83258109a75555cf353c