### PR TITLE
Improve mobile responsiveness across elearn pages

### DIFF
--- a/magicmirror-node/public/elearn/login-elearning.html
+++ b/magicmirror-node/public/elearn/login-elearning.html
@@ -148,6 +148,19 @@
       position: relative;
     }
 
+  @media (max-width: 600px) {
+    .input-container input, input[type="email"], input[type="password"] {
+      width: 90vw;
+    }
+    .login-button-container {
+      width: 120px;
+      height: 120px;
+    }
+    #login-btn {
+      width: 100px;
+      top: 40px;
+    }
+  }
   </style>
 </head>
 <body>

--- a/magicmirror-node/public/elearn/style.css
+++ b/magicmirror-node/public/elearn/style.css
@@ -1,0 +1,76 @@
+/* Base layout styles */
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.progress-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.progress-table th,
+.progress-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.progress-table th {
+  background: #f5f5f5;
+}
+
+/* Login page elements */
+.login-wrapper {
+  width: 100%;
+  max-width: 400px;
+}
+
+.input-container input {
+  width: 100%;
+  max-width: 400px;
+}
+
+.login-button-container {
+  width: 160px;
+  height: 160px;
+  margin: 0 auto;
+}
+
+#login-btn {
+  width: 140px;
+  height: 50px;
+  top: 50px;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 10px;
+  }
+
+  .progress-table th,
+  .progress-table td {
+    font-size: 14px;
+  }
+
+  .login-wrapper {
+    margin-top: 20px;
+    padding: 0 10px;
+  }
+
+  .login-button-container {
+    width: 120px;
+    height: 120px;
+  }
+
+  #login-btn {
+    width: 100px;
+    top: 40px;
+  }
+}

--- a/magicmirror-node/public/elearn/template.html
+++ b/magicmirror-node/public/elearn/template.html
@@ -2,6 +2,7 @@
 <html lang="id">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lesson Template</title>
   <link rel="stylesheet" href="/elearn/style.css">
   <link rel="stylesheet" href="/elearn/template-style.css">


### PR DESCRIPTION
## Summary
- add base responsive layout in `style.css`
- tweak login page styles for small screens
- ensure lesson template loads viewport meta

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684860ea225c83259dc8d589268d27fa