### PR TITLE
Fix Astro lesson access check

### DIFF
--- a/magicmirror-node/public/elearn/L1-ASTRO1.html
+++ b/magicmirror-node/public/elearn/L1-ASTRO1.html
@@ -208,7 +208,8 @@
 <script>
   // Validasi session user
   const user = getUserInfo();
-  if (!user || user.role !== "anak") {
+  // Ijinkan akses jika setidaknya terdapat CID atau UID terdeteksi
+  if (!user || (!user.cid && !user.uid)) {
     alert("❌ Akses tidak sah. Silakan login ulang.");
     window.location.href = "/elearn/login-elearning.html";
   }

--- a/magicmirror-node/public/elearn/template-common.js
+++ b/magicmirror-node/public/elearn/template-common.js
@@ -4,7 +4,8 @@
 
 window.addEventListener("DOMContentLoaded", () => {
   const user = getUserInfo();
-  if (!user || user.role !== "anak") {
+  // Ijinkan akses jika CID atau UID tersedia
+  if (!user || (!user.cid && !user.uid)) {
     alert("❌ Akses tidak sah. Silakan login ulang.");
     window.location.href = "/elearn/login-elearning.html";
     return;
@@ -28,9 +29,10 @@ window.addEventListener("DOMContentLoaded", () => {
 
 function getUserInfo() {
   return {
-    email: sessionStorage.getItem("email"),
-    role: sessionStorage.getItem("role"),
-    nama: sessionStorage.getItem("nama"),
-    uid: sessionStorage.getItem("uid_custom")
+    email: localStorage.getItem("email"),
+    role: localStorage.getItem("role"),
+    nama: localStorage.getItem("nama"),
+    uid: localStorage.getItem("uid"),
+    cid: localStorage.getItem("cid")
   };
 }


### PR DESCRIPTION
## Summary
- allow lesson pages to load if either cid or uid is present
- look for user info in `localStorage` inside the lesson template

## Testing
- `npm start` *(fails: Cannot find module 'axios')*
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684981e03c7083259f0676990f67ea55