### PR TITLE
Add Blockly Playground button

### DIFF
--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -29,6 +29,10 @@
       <span class="material-icons icon icon-emboss">smart_toy</span>
       <span>Robotic</span>
     </a>
+    <a href="https://blockly-playground.onrender.com" target="_blank">
+      <span class="material-icons icon icon-emboss">extension</span>
+      <span>Blockly Playground</span>
+    </a>
     <a href="javascript:void(0);" onclick="handleLogout()">
       <span class="material-icons icon icon-emboss">logout</span>
       <span>Logout</span>


### PR DESCRIPTION
## Summary
- add link to Blockly Playground in sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fae2c25e48325b20495449eccd299