### PR TITLE
Add inline error display for turtle playground

### DIFF
--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -13,6 +13,7 @@
       <span class="material-icons icon icon-emboss">assignment</span>
       <span>Free Trial</span>
     </a>
+    <!--
     <a href="/elearn/modul1_lesson1.html">
       <span class="material-icons icon icon-emboss">insights</span>
       <span>Progress</span>
@@ -28,6 +29,11 @@
     <a href="/elearn/indexRobotic.html">
       <span class="material-icons icon icon-emboss">smart_toy</span>
       <span>Robotic</span>
+    </a>
+    -->
+    <a href="https://blockly-playground.onrender.com" target="_blank">
+      <span class="material-icons icon icon-emboss">extension</span>
+      <span>Blockly Playground</span>
     </a>
     <a href="javascript:void(0);" onclick="handleLogout()">
       <span class="material-icons icon icon-emboss">logout</span>

--- a/magicmirror-node/public/elearn/turtle-playground.html
+++ b/magicmirror-node/public/elearn/turtle-playground.html
@@ -58,6 +58,7 @@ turtle.left(90)
 turtle.forward(100)
   </textarea>
   <button id="runBtn">Jalankan Kode</button>
+  <div id="status" style="margin-top:10px;color:red"></div>
   <canvas id="turtleCanvas" width="500" height="500"></canvas>
 
   <script>
@@ -65,11 +66,16 @@ turtle.forward(100)
     const turtle = new Turtle(canvas);
 
     document.getElementById('runBtn').onclick = function () {
+      const status = document.getElementById('status');
+      status.textContent = '';
       turtle.reset();
       try {
         eval(document.getElementById('editor').value);
+        status.style.color = 'green';
+        status.textContent = '✅ Program selesai';
       } catch (e) {
-        alert("Ada error di kode kamu:\n" + e.message);
+        status.style.color = 'red';
+        status.textContent = '❌ ' + e.message;
       }
     };
   </script>


### PR DESCRIPTION
## Summary
- display turtle playground errors in-page instead of alerts
- hide extra sidebar buttons and keep the new Blockly Playground link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fae2c25e48325b20495449eccd299