### PR TITLE
Fix puzzle image preview

### DIFF
--- a/magicmirror-node/public/puzzle/puzzle.html
+++ b/magicmirror-node/public/puzzle/puzzle.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <title>Puzzle Blockly</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <script src="puzzle_blocks.js"></script>
+  <script src="puzzle.js" defer></script>
+</head>
+<body>
+  <button id="check-btn" class="check-btn">Periksa Jawaban</button>
+  <canvas id="previewCanvas" width="200" height="200" class="preview-canvas"></canvas>
+  <div id="blocklyDiv" class="blockly-container"></div>
+  <xml id="toolbox" style="display:none">
+    <block type="ciri"></block>
+    <block type="kaki"></block>
+    <block type="gambar"></block>
+    <block type="hewan_kucing"></block>
+    <block type="hewan_lebah"></block>
+    <block type="hewan_bebek"></block>
+    <block type="hewan_siput"></block>
+  </xml>
+</body>
+</html>

--- a/magicmirror-node/public/puzzle/puzzle.js
+++ b/magicmirror-node/public/puzzle/puzzle.js
@@ -1,0 +1,104 @@
+const ANIMALS = {
+  kucing: {
+    image: 'https://twemoji.maxcdn.com/v/latest/72x72/1f431.png',
+    legs: '4',
+    ciri: ['memiliki kumis', 'suka susu']
+  },
+  lebah: {
+    image: 'https://twemoji.maxcdn.com/v/latest/72x72/1f41d.png',
+    legs: '6',
+    ciri: ['menghasilkan madu', 'dapat menyengat']
+  },
+  bebek: {
+    image: 'https://twemoji.maxcdn.com/v/latest/72x72/1f986.png',
+    legs: '2',
+    ciri: ['bisa berenang', 'mengeluarkan suara kwek']
+  },
+  siput: {
+    image: 'https://twemoji.maxcdn.com/v/latest/72x72/1f40c.png',
+    legs: '0',
+    ciri: ['bergerak lambat', 'memiliki cangkang']
+  }
+};
+
+const workspace = Blockly.inject('blocklyDiv', {
+  toolbox: document.getElementById('toolbox')
+});
+
+function drawImage(url) {
+  const ctx = document.getElementById('previewCanvas').getContext('2d');
+  const img = new Image();
+  img.onload = () => {
+    ctx.clearRect(0, 0, 400, 400);
+    ctx.drawImage(img, 50, 50, 200, 200);
+  };
+  img.src = url;
+}
+
+function createBlock(type, fields = {}) {
+  const block = workspace.newBlock(type);
+  for (const [name, value] of Object.entries(fields)) {
+    block.setFieldValue(value, name);
+  }
+  block.initSvg();
+  block.render();
+  const metrics = workspace.getMetrics();
+  const x = Math.random() * (metrics.viewWidth - 100) + metrics.absoluteLeft;
+  const y = Math.random() * (metrics.viewHeight - 100) + metrics.absoluteTop;
+  block.moveBy(x, y);
+  return block;
+}
+
+function init() {
+  Object.entries(ANIMALS).forEach(([name, data]) => {
+    createBlock('hewan_' + name);
+    createBlock('gambar', {SRC: data.image});
+    createBlock('kaki', {NUM: data.legs});
+    data.ciri.forEach(text => createBlock('ciri', {TEXT: text}));
+  });
+}
+
+function getCiriTexts(block) {
+  const texts = [];
+  let b = block.getInputTargetBlock('CIRI');
+  while (b) {
+    texts.push(b.getFieldValue('TEXT').trim());
+    b = b.getNextBlock();
+  }
+  return texts;
+}
+
+function checkAnswer() {
+  let correct = true;
+  let imageCorrect = true;
+  for (const [name, data] of Object.entries(ANIMALS)) {
+    const animalBlock = workspace.getBlocksByType('hewan_' + name, false)[0];
+    if (!animalBlock) { correct = false; imageCorrect = false; break; }
+    const imgBlock = animalBlock.getInputTargetBlock('GAMBAR');
+    const url = imgBlock ? imgBlock.getFieldValue('SRC').trim() : '';
+    if (!imgBlock || url !== data.image) {
+      correct = false;
+      imageCorrect = false;
+    } else {
+      drawImage(url);
+    }
+    const legBlock = animalBlock.getInputTargetBlock('KAKI');
+    if (!legBlock || legBlock.getFieldValue('NUM') !== data.legs) {
+      correct = false;
+    }
+    const ciris = getCiriTexts(animalBlock).sort();
+    const expected = data.ciri.slice().sort();
+    if (ciris.length !== expected.length || ciris.some((c,i) => c !== expected[i])) {
+      correct = false;
+    }
+  }
+  const topBlocks = workspace.getTopBlocks(false);
+  const allowed = Object.keys(ANIMALS).map(a => 'hewan_' + a);
+  if (topBlocks.some(b => !allowed.includes(b.type))) correct = false;
+  alert(imageCorrect ? '✅ Gambar benar' : '❌ Gambar salah');
+  alert(correct ? '✅ Semua benar!' : '❌ Masih ada yang salah');
+}
+
+document.getElementById('check-btn').addEventListener('click', checkAnswer);
+
+init();

--- a/magicmirror-node/public/puzzle/puzzle_blocks.js
+++ b/magicmirror-node/public/puzzle/puzzle_blocks.js
@@ -1,0 +1,98 @@
+Blockly.defineBlocksWithJsonArray([
+  {
+    "type": "ciri",
+    "message0": "%1",
+    "args0": [
+      {"type": "field_input", "name": "TEXT", "text": "ciri"}
+    ],
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": 290
+  },
+  {
+    "type": "kaki",
+    "message0": "kaki %1",
+    "args0": [
+      {"type": "field_dropdown", "name": "NUM", "options": [["0","0"],["2","2"],["4","4"],["6","6"]]}
+    ],
+    "output": "Number",
+    "colour": 120
+  },
+  {
+    "type": "gambar",
+    "message0": "gambar %1",
+    "args0": [
+      {"type": "field_input", "name": "SRC", "text": "url"}
+    ],
+    "output": "String",
+    "colour": 20
+  },
+  {
+    "type": "hewan_kucing",
+    "message0": "kucing",
+    "message1": "gambar %1",
+    "args1": [
+      {"type": "input_value", "name": "GAMBAR", "check": "String"}
+    ],
+    "message2": "kaki %1",
+    "args2": [
+      {"type": "input_value", "name": "KAKI", "check": "Number"}
+    ],
+    "message3": "ciri-ciri %1",
+    "args3": [
+      {"type": "input_statement", "name": "CIRI"}
+    ],
+    "colour": 100
+  },
+  {
+    "type": "hewan_lebah",
+    "message0": "lebah",
+    "message1": "gambar %1",
+    "args1": [
+      {"type": "input_value", "name": "GAMBAR", "check": "String"}
+    ],
+    "message2": "kaki %1",
+    "args2": [
+      {"type": "input_value", "name": "KAKI", "check": "Number"}
+    ],
+    "message3": "ciri-ciri %1",
+    "args3": [
+      {"type": "input_statement", "name": "CIRI"}
+    ],
+    "colour": 100
+  },
+  {
+    "type": "hewan_bebek",
+    "message0": "bebek",
+    "message1": "gambar %1",
+    "args1": [
+      {"type": "input_value", "name": "GAMBAR", "check": "String"}
+    ],
+    "message2": "kaki %1",
+    "args2": [
+      {"type": "input_value", "name": "KAKI", "check": "Number"}
+    ],
+    "message3": "ciri-ciri %1",
+    "args3": [
+      {"type": "input_statement", "name": "CIRI"}
+    ],
+    "colour": 100
+  },
+  {
+    "type": "hewan_siput",
+    "message0": "siput",
+    "message1": "gambar %1",
+    "args1": [
+      {"type": "input_value", "name": "GAMBAR", "check": "String"}
+    ],
+    "message2": "kaki %1",
+    "args2": [
+      {"type": "input_value", "name": "KAKI", "check": "Number"}
+    ],
+    "message3": "ciri-ciri %1",
+    "args3": [
+      {"type": "input_statement", "name": "CIRI"}
+    ],
+    "colour": 100
+  }
+]);

--- a/magicmirror-node/public/puzzle/styles.css
+++ b/magicmirror-node/public/puzzle/styles.css
@@ -1,0 +1,30 @@
+html,body{
+  height:100%;
+  margin:0;
+}
+.blockly-container{
+  height:100vh;
+  width:100%;
+}
+.check-btn{
+  position:absolute;
+  top:10px;
+  right:10px;
+  z-index:99;
+  padding:8px 16px;
+  background:#4caf50;
+  color:#fff;
+  border:none;
+  border-radius:4px;
+  cursor:pointer;
+}
+.preview-canvas{
+  position:absolute;
+  top:60px;
+  right:10px;
+  width:200px;
+  height:200px;
+  background:#fff;
+  border:1px solid #ccc;
+  z-index:90;
+}


### PR DESCRIPTION
## Summary
- add preview `<canvas>` to puzzle
- show images while validating answers with `drawImage`

## Testing
- `npm test --prefix magicmirror-node` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0bcc4b883259f3b267e7b3a8027