### PR TITLE
Add submenu links for Blockly Playground

### DIFF
--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -32,13 +32,25 @@
     </a>
     -->
 
-    <a href="https://blockly-playground.onrender.com" target="_blank">
-      <span class="material-icons icon icon-emboss">extension</span>
-      <span>Blockly Playground</span>
-    </a>
+    <div class="submenu-parent">
+      <a href="javascript:void(0);" class="submenu-toggle" onclick="toggleSubmenu('blockly-submenu')">
+        <span class="material-icons icon icon-emboss">extension</span>
+        <span>Blockly Playground ▾</span>
+      </a>
+      <div id="blockly-submenu" class="submenu">
+        <a href="https://queensacademy.id/puzzle/puzzle.html" target="_blank">Puzzle</a>
+        <a href="https://queensacademy.id/blockly/blockly.html" target="_blank">Blockly</a>
+        <a href="https://queensacademy.id/maze/maze.html" target="_blank">Maze</a>
+        <a href="https://blockly-playground.onrender.com/" target="_blank">Playground</a>
+      </div>
+    </div>
     <a href="javascript:void(0);" onclick="handleLogout()">
       <span class="material-icons icon icon-emboss">logout</span>
       <span>Logout</span>
     </a>
   </nav>
 </div>
+<style>
+  .submenu { display: none; flex-direction: column; }
+  .submenu a { margin-left: 32px; }
+</style>

--- a/magicmirror-node/public/elearn/sidebar.js
+++ b/magicmirror-node/public/elearn/sidebar.js
@@ -15,6 +15,13 @@ function toggleSidebar() {
   if (sidebar) sidebar.classList.toggle('collapsed');
 }
 
+function toggleSubmenu(id) {
+  const submenu = document.getElementById(id);
+  if (submenu) {
+    submenu.style.display = submenu.style.display === 'flex' ? 'none' : 'flex';
+  }
+}
+
 function handleLogout() {
   firebase.auth().signOut().then(() => {
     sessionStorage.clear();


### PR DESCRIPTION
## Summary
- add new submenu in `sidebar.html` so Blockly Playground opens links to several coding games
- add styles for the submenu and a JS helper to toggle it

## Testing
- `npm test` in `magicmirror-node` *(fails: Missing script)*
- `npm test` in `firebase-upload-backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851304df0908325953fd3191969b231