### PR TITLE
Add default page for /maze path

### DIFF
--- a/magicmirror-node/public/maze/index.html
+++ b/magicmirror-node/public/maze/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta http-equiv="refresh" content="0; url=maze.html" />
+  <title>Maze</title>
+</head>
+<body>
+  Jika tidak diarahkan otomatis, <a href="maze.html">klik di sini</a>.
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` under `magicmirror-node/public/maze` to redirect to `maze.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851377d2ce0832586b5b558953c67b2