### PR TITLE
Redirect digital literacy module

### DIFF
--- a/magicmirror-node/public/elearn/modul.html
+++ b/magicmirror-node/public/elearn/modul.html
@@ -447,7 +447,7 @@
             <span class="lesson-number">DL L1</span>
             <h3>Digital Literacy</h3>
             <p>DL L1: Pengenalan Dunia Digital</p>
-            <a href="#" class="start-btn">Lihat Modul</a>
+            <a href="https://digital-literacy-hmz4.onrender.com/" class="start-btn">Lihat Modul</a>
           </div>
           <div class="lesson-cards-container" style="display:none;">
             <a href="/elearn/DLL1.html" style="text-decoration:none;">
@@ -953,6 +953,11 @@
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.start-btn').forEach(btn => {
         btn.addEventListener('click', e => {
+          const href = btn.getAttribute('href');
+          if (href && href !== '#') {
+            window.location = href;
+            return;
+          }
           e.preventDefault();
           const container = btn.closest('.lesson-card').nextElementSibling;
           if (container && container.classList.contains('lesson-cards-container')) {


### PR DESCRIPTION
## Summary
- update the Digital Literacy module button link
- bypass expand/collapse logic when a start button has an external URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686981de45c88325b380dda4c76fa1e5