### PR TITLE
Fix hidden submenu item

### DIFF
--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -53,6 +53,11 @@
   </nav>
 </div>
 <style>
-  .submenu { display: none; flex-direction: column; }
+  .submenu {
+    display: none;
+    flex-direction: column;
+    max-height: 200px;
+    overflow-y: auto;
+  }
   .submenu a { margin-left: 32px; }
 </style>


### PR DESCRIPTION
## Summary
- allow the Playground submenu to scroll

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab3ef34208325a550db3a1544d7e5