### PR TITLE
Add reCAPTCHA verification middleware

### DIFF
--- a/magicmirror-node/public/elearn/login-elearning.html
+++ b/magicmirror-node/public/elearn/login-elearning.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="style.css" />
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <script>
     const firebaseConfig = {
       apiKey: "AIzaSyBVO4ajDwkbcTGL33SVMxIoev4veB8itgI",
@@ -175,6 +176,7 @@
       <input type="password" id="password" placeholder="Password" />
     </div>
 
+    <div class="g-recaptcha" data-sitekey="6Ldyv38rAAAAAJ9khQ2Dff03PEMAhzRJCrQZC-UM"></div>
     <!-- Login Button -->
     <div class="login-button-container">
       <button onclick="login()" id="login-btn"></button>
@@ -195,13 +197,34 @@ async function login() {
   const email = document.getElementById("email").value.trim();
   const password = document.getElementById("password").value.trim();
   const errorEl = document.getElementById("error-message");
+  const captchaToken = grecaptcha.getResponse();
 
   if (!email || !password) {
     errorEl.innerText = "❗ Email dan password harus diisi.";
     return;
   }
 
+  if (!captchaToken) {
+    errorEl.innerText = "❗ Verifikasi CAPTCHA terlebih dahulu.";
+    return;
+  }
+
   try {
+    const verifyRes = await fetch("/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: email,
+        password,
+        "g-recaptcha-response": captchaToken
+      })
+    });
+    const verifyData = await verifyRes.json();
+    if (!verifyRes.ok || !verifyData.success) {
+      errorEl.innerText = verifyData.error || "❌ Login gagal.";
+      grecaptcha.reset();
+      return;
+    }
     const userCred = await firebase.auth().signInWithEmailAndPassword(email, password);
     const uid = userCred.user.uid;
 

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -16,6 +16,28 @@ app.use(express.json({ limit: '10mb' })); // untuk terima JSON besar (seperti fo
 app.use('/generated_lessons', express.static(path.join(__dirname, '..', 'generated_lessons')));
 app.use(uploadModulRouter);
 
+async function verifyRecaptcha(req, res, next) {
+  const token = req.body["g-recaptcha-response"];
+  if (!token) {
+    return res.status(403).json({ success: false, error: "Verifikasi CAPTCHA gagal" });
+  }
+  try {
+    const secret = process.env.RECAPTCHA_SECRET;
+    const gRes = await axios.post(
+      "https://www.google.com/recaptcha/api/siteverify",
+      null,
+      { params: { secret, response: token } }
+    );
+    if (gRes.data.success) {
+      return next();
+    }
+    return res.status(403).json({ success: false, error: "Verifikasi CAPTCHA gagal" });
+  } catch (err) {
+    console.error("reCAPTCHA verify error:", err?.response?.data || err.message);
+    return res.status(403).json({ success: false, error: "Verifikasi CAPTCHA gagal" });
+  }
+}
+
 // Endpoint: Sinkronisasi data Form Responses 1 ke PROFILE_ANAK berdasarkan CID
 app.get("/sync-profile-anak", async (req, res) => {
   const { google } = require("googleapis");
@@ -143,8 +165,8 @@ app.post("/ganti-password", async (req, res) => {
 });
 
 // Endpoint login user
-app.get("/login", async (req, res) => {
-    const { username, password } = req.query;
+app.post("/login", verifyRecaptcha, async (req, res) => {
+    const { username, password } = req.body;
   
     // Fetch data dari Google Sheet PROFILE_ANAK
     const sheetData = await getProfileAnakData(); // Fungsi ini ambil data sheet


### PR DESCRIPTION
## Summary
- use Google reCAPTCHA checkbox on the login page
- send reCAPTCHA token as `g-recaptcha-response`
- validate CAPTCHA tokens server-side before processing login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687156dfce2083259441c9acaffec9b5