### PR TITLE
Add moderator dashboard page

### DIFF
--- a/elearn/moderator.html
+++ b/elearn/moderator.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Moderator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin:20px; background:#f0f4f8; }
+    h1 { text-align:center; }
+    table { width:100%; border-collapse:collapse; margin-top:20px; }
+    th, td { padding:8px 12px; border:1px solid #ccc; }
+    th { background:#e8eff5; }
+    button { padding:6px 12px; cursor:pointer; }
+    form { margin-top:30px; max-width:500px; }
+    input, select { width:100%; padding:8px; margin:6px 0; }
+    #students-section { margin-top:40px; }
+    @media (max-width:600px) {
+      table, thead, tbody, th, td, tr { display:block; }
+      th { position:absolute; top:-9999px; left:-9999px; }
+      td { border:none; position:relative; padding-left:50%; }
+      td:before { content: attr(data-label); position:absolute; left:0; width:45%; padding-left:10px; font-weight:bold; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Dashboard Moderator</h1>
+
+  <section id="class-section">
+    <h2>Daftar Kelas</h2>
+    <table id="kelas-table">
+      <thead>
+        <tr>
+          <th>Kelas ID</th>
+          <th>Nama Kelas</th>
+          <th>Guru ID</th>
+          <th>Jumlah Murid</th>
+          <th>Aksi</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="students-section">
+    <h2>Daftar Murid</h2>
+    <table id="students-table">
+      <thead>
+        <tr><th>CID</th><th>Nama</th><th>Email</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="add-class">
+    <h2>Tambah Kelas Baru</h2>
+    <form id="form-add-class">
+      <input type="text" id="kelas_id" placeholder="Kelas ID" required>
+      <input type="text" id="nama_kelas" placeholder="Nama Kelas" required>
+      <input type="text" id="guru_id" placeholder="Guru ID" required>
+      <button type="submit">Tambah Kelas</button>
+    </form>
+    <p id="class-status"></p>
+  </section>
+
+  <section id="add-student">
+    <h2>Tambah Akun</h2>
+    <form id="form-add-student">
+      <input type="text" id="nama" placeholder="Nama" required>
+      <input type="email" id="email" placeholder="Email" required>
+      <input type="password" id="password" placeholder="Password" required>
+      <input type="text" id="kelas_id_student" placeholder="Kelas ID" required>
+      <select id="role">
+        <option value="murid">Murid</option>
+        <option value="guru">Guru</option>
+        <option value="moderator">Moderator</option>
+      </select>
+      <button type="submit">Tambah Akun</button>
+    </form>
+    <p id="student-status"></p>
+  </section>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const role = localStorage.getItem('role');
+    if (role !== 'moderator') {
+      window.location.href = '/elearn/login-elearning.html';
+      return;
+    }
+
+    loadClasses();
+    document.getElementById('form-add-class').addEventListener('submit', addClass);
+    document.getElementById('form-add-student').addEventListener('submit', addStudent);
+  });
+
+  async function loadClasses() {
+    try {
+      const res = await fetch('/api/kelas');
+      const data = await res.json();
+      const tbody = document.querySelector('#kelas-table tbody');
+      tbody.innerHTML = '';
+      data.forEach(kelas => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td data-label="Kelas ID">${kelas.kelas_id}</td>
+          <td data-label="Nama Kelas">${kelas.nama_kelas}</td>
+          <td data-label="Guru ID">${kelas.guru_id}</td>
+          <td data-label="Jumlah Murid">${kelas.jumlah_murid || 0}</td>
+          <td data-label="Aksi"><button data-id="${kelas.kelas_id}">Lihat Murid</button></td>`;
+        tr.querySelector('button').addEventListener('click', () => loadStudents(kelas.kelas_id));
+        tbody.appendChild(tr);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function loadStudents(kelasId) {
+    try {
+      const res = await fetch(`/api/kelas/${kelasId}`);
+      const data = await res.json();
+      const tbody = document.querySelector('#students-table tbody');
+      tbody.innerHTML = '';
+      data.forEach(murid => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td data-label="CID">${murid.cid}</td>
+          <td data-label="Nama">${murid.nama}</td>
+          <td data-label="Email">${murid.email}</td>`;
+        tbody.appendChild(tr);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function addClass(e) {
+    e.preventDefault();
+    const status = document.getElementById('class-status');
+    const kelas_id = document.getElementById('kelas_id').value.trim();
+    const nama_kelas = document.getElementById('nama_kelas').value.trim();
+    const guru_id = document.getElementById('guru_id').value.trim();
+    try {
+      const res = await fetch('/api/kelas', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kelas_id, nama_kelas, guru_id })
+      });
+      if (res.ok) {
+        status.textContent = '✅ Kelas berhasil ditambah.';
+        loadClasses();
+        e.target.reset();
+      } else {
+        const data = await res.json();
+        status.textContent = '❌ ' + (data.error || 'Gagal menambah kelas');
+      }
+    } catch (err) {
+      console.error(err);
+      status.textContent = '❌ Gagal menambah kelas';
+    }
+  }
+
+  async function addStudent(e) {
+    e.preventDefault();
+    const status = document.getElementById('student-status');
+    const nama = document.getElementById('nama').value.trim();
+    const email = document.getElementById('email').value.trim();
+    const password = document.getElementById('password').value.trim();
+    const kelas_id = document.getElementById('kelas_id_student').value.trim();
+    const role = document.getElementById('role').value;
+    try {
+      const res = await fetch('/api/daftar-akun-baru', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nama, email, password, kelas_id, role })
+      });
+      if (res.ok) {
+        status.textContent = '✅ Akun berhasil ditambah.';
+        e.target.reset();
+        loadClasses();
+      } else {
+        const data = await res.json();
+        status.textContent = '❌ ' + (data.error || 'Gagal menambah akun');
+      }
+    } catch (err) {
+      console.error(err);
+      status.textContent = '❌ Gagal menambah akun';
+    }
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `moderator.html` for moderator dashboard in `elearn`
- page validates moderator role from `localStorage`
- list classes via `/api/kelas` with view students action
- allow adding new class and new user via forms

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687205a6b21c8325801ed17cc96f3a37