### PR TITLE
Add student list API and dropdown for moderator

### DIFF
--- a/magicmirror-node/public/elearn/moderator.html
+++ b/magicmirror-node/public/elearn/moderator.html
@@ -82,7 +82,7 @@
   <section id="assign-student-section">
     <h2>Assign Murid ke Kelas</h2>
     <form id="form-assign-student">
-      <input type="text" id="assign_uid" placeholder="UID Murid" required>
+      <select id="assign_uid"></select>
       <input type="text" id="assign_kelas_id" placeholder="Kelas ID Tujuan" required>
       <button type="submit">Assign Murid</button>
     </form>
@@ -98,6 +98,7 @@
     }
 
     loadClasses();
+    loadAllStudents();
     document.getElementById('form-add-class').addEventListener('submit', addClass);
     document.getElementById('form-add-student').addEventListener('submit', addStudent);
   });
@@ -141,6 +142,26 @@
       });
     } catch (err) {
       console.error(err);
+    }
+  }
+
+  async function loadAllStudents() {
+    const select = document.getElementById('assign_uid');
+    const status = document.getElementById('assign-status');
+    try {
+      const res = await fetch('/api/semua-murid');
+      if (!res.ok) throw new Error('Network');
+      const list = await res.json();
+      select.innerHTML = '<option value="">Pilih Murid</option>';
+      list.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.uid;
+        opt.textContent = `${m.nama} (${m.email})`;
+        select.appendChild(opt);
+      });
+    } catch (err) {
+      console.error(err);
+      status.textContent = '❌ Gagal memuat daftar murid';
     }
   }
 

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -284,6 +284,21 @@ async function getProfileAnakData() {
 }
 
 // ======= E-learning Moderator Endpoints =======
+// GET /api/semua-murid - daftar semua murid (uid, nama, email)
+app.get('/api/semua-murid', async (req, res) => {
+  try {
+    const snap = await db.collection('murid').get();
+    const data = snap.docs.map(d => {
+      const val = d.data();
+      return { uid: d.id, nama: val.nama || '', email: val.email || '' };
+    });
+    res.json(data);
+  } catch (err) {
+    console.error('❌ Error get semua murid:', err);
+    res.status(500).json([]);
+  }
+});
+
 // GET /api/kelas - daftar semua kelas
 app.get('/api/kelas', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add `/api/semua-murid` endpoint in server
- change assign student input to dropdown
- load all students on page load and populate dropdown
- show error message when student list fetch fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68723e89f990832590077e82baf25716