### PR TITLE
Fix interactive lesson load & add lesson API

### DIFF
--- a/magicmirror-node/public/elearn/interactive-lessons.html
+++ b/magicmirror-node/public/elearn/interactive-lessons.html
@@ -426,16 +426,24 @@
     if (document.getElementById('form-add-student')) {
       document.getElementById('form-add-student').addEventListener('submit', addStudent);
     }
+    if (document.getElementById('form-add-lesson')) {
+      document.getElementById('form-add-lesson').addEventListener('submit', addLesson);
+    }
   });
 
   // Load lessons and populate lesson table
   async function loadLessons() {
     try {
       const res = await fetch(`${FIREBASE_API}/api/lessons`);
-      const list = await res.json();
+      if (!res.ok) {
+        const txt = await res.text();
+        throw new Error(`HTTP ${res.status} - ${txt}`);
+      }
+      const data = await res.json();
+      const list = Array.isArray(data.lessons) ? data.lessons : (Array.isArray(data) ? data : []);
 
       if (!Array.isArray(list)) {
-        console.error('❌ Invalid data format: lessons must be an array', list);
+        console.error('❌ Invalid data format: lessons must be an array', data);
         return;
       }
 
@@ -545,6 +553,34 @@
     } catch (err) {
       console.error(err);
       if (status) status.textContent = '❌ Gagal menambah akun';
+    }
+  }
+
+  async function addLesson(e) {
+    e.preventDefault();
+    const statusEl = document.getElementById('lesson-status');
+    const title = document.getElementById('lesson_title').value.trim();
+    const module = document.getElementById('lesson_module').value.trim();
+    const lesson_id = document.getElementById('lesson_code').value.trim();
+    const lessonStatus = document.getElementById('lesson_status').value;
+
+    try {
+      const res = await fetch(`${FIREBASE_API}/api/lessons`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lesson_id, title, module, status: lessonStatus })
+      });
+      if (res.ok) {
+        if (statusEl) statusEl.textContent = '✅ Lesson berhasil ditambah.';
+        e.target.reset();
+        loadLessons();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        if (statusEl) statusEl.textContent = '❌ ' + (data.error || 'Gagal menambah lesson');
+      }
+    } catch (err) {
+      console.error(err);
+      if (statusEl) statusEl.textContent = '❌ Gagal menambah lesson';
     }
   }
   if (document.getElementById('form-assign-student')) {

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -350,6 +350,36 @@ app.get('/api/lessons', async (req, res) => {
   }
 });
 
+// POST /api/lessons - tambah lesson baru
+app.post('/api/lessons', async (req, res) => {
+  const { lesson_id, title, module, status, kelas_id } = req.body;
+  if (!lesson_id || !title || !module) {
+    return res.status(400).json({ success: false, error: 'Data tidak lengkap' });
+  }
+
+  try {
+    const ref = db.collection('lessons').doc(lesson_id);
+    const exist = await ref.get();
+    if (exist.exists) {
+      return res.status(400).json({ success: false, error: 'lesson_id sudah ada' });
+    }
+
+    await ref.set({
+      lesson_id,
+      title,
+      module,
+      kelas_id: kelas_id || '',
+      status: status || 'active',
+      created: Date.now()
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('❌ Error add lesson:', err);
+    res.status(500).json({ success: false, error: 'Server error' });
+  }
+});
+
 // ======= E-learning Moderator Endpoints =======
 // GET /api/semua-murid - daftar semua murid (uid, nama, email)
 app.get('/api/semua-murid', async (req, res) => {


### PR DESCRIPTION
## Summary
- support lesson creation via `/api/lessons`
- improve lesson loader and add front‑end form handler

## Testing
- `npm test --prefix magicmirror-node` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a4109e1d48325af0a1444b585ed4c