### PR TITLE
Fix JS syntax errors in interactive lessons page

### DIFF
--- a/magicmirror-node/public/elearn/interactive-lessons.html
+++ b/magicmirror-node/public/elearn/interactive-lessons.html
@@ -463,6 +463,7 @@
           <td><button data-id="${lesson.lesson_id}">View</button></td>
         `;
         tbody.appendChild(tr);
+      });
       document.getElementById('stat-total-lessons').textContent = list.length;
     } catch (err) {
       console.error('❌ Failed to load lessons:', err);
@@ -483,6 +484,7 @@
           <td data-label="Nama"><a href="/elearn/student-profile.html?cid=${murid.cid}">${murid.nama}</a></td>
           <td data-label="Email">${murid.email}</td>`;
         tbody.appendChild(tr);
+      });
     } catch (err) {
       console.error(err);
     }
@@ -511,6 +513,7 @@
           opt2.textContent = `${m.nama} (${m.cid})`;
           selectLesson.appendChild(opt2);
         }
+      });
       // Update stat card murid
       if (document.getElementById('stat-murid')) {
         document.getElementById('stat-murid').textContent = list.length;
@@ -541,6 +544,7 @@
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cid, nama, email, password, wa, kelas_id, role })
+      });
       if (res.ok) {
         if (status) status.textContent = '✅ Akun berhasil ditambah.';
         e.target.reset();
@@ -568,6 +572,7 @@
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ lesson_id, title, module, status: lessonStatus })
+      });
       const text = await res.text();
       let data = {};
       if (text) {
@@ -606,6 +611,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ cid, lesson })
+        });
         if (res.ok) {
           if (status) status.textContent = '✅ Akses lesson berhasil ditambahkan.';
           e.target.reset();
@@ -623,6 +629,7 @@
         console.error(err);
         if (status) status.textContent = '❌ Gagal assign lesson';
       }
+    });
   }
 
   async function assignStudent(e) {
@@ -635,6 +642,7 @@
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ uid, kelas_id })
+      });
       if (res.ok) {
         if (status) status.textContent = '✅ Murid berhasil di-assign ke kelas.';
         e.target.reset();
@@ -648,7 +656,7 @@
       if (status) status.textContent = '❌ Gagal assign murid';
     }
   }
- </script>
+</script>
 
 
   <script>
@@ -682,6 +690,7 @@
       if (currentTheme === 'dark') {
         document.getElementById('sidebar-container')?.classList.add('dark-theme');
       }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- close missing `forEach` and fetch calls
- finish event listeners with closing brackets
- add newline at EOF
- close `assignStudent` function properly

## Testing
- `npm test` *(fails: Missing script)*
- `cd magicmirror-node && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f56d281748325aac98228eb5104dc