### PR TITLE
Fix lesson access API handling

### DIFF
--- a/magicmirror-node/public/elearn/lesson-access.html
+++ b/magicmirror-node/public/elearn/lesson-access.html
@@ -436,59 +436,69 @@
       if (document.getElementById('user-name')) {
         document.getElementById('user-name').textContent = userName;
       }
+    });
   </script>
-</body>
-<script>
-  // Theme toggle switch logic
-  const themeToggle = document.getElementById("themeToggle");
-  themeToggle.addEventListener("change", function () {
-    document.body.classList.toggle("dark-theme", this.checked);
-    localStorage.setItem("theme", this.checked ? "dark" : "light");
+  <script>
+    // Theme toggle switch logic
+    const themeToggle = document.getElementById("themeToggle");
+    themeToggle.addEventListener("change", function () {
+      document.body.classList.toggle("dark-theme", this.checked);
+      localStorage.setItem("theme", this.checked ? "dark" : "light");
+    });
 
-  window.addEventListener("DOMContentLoaded", () => {
-    const savedTheme = localStorage.getItem("theme");
-    if (savedTheme === "dark") {
-      document.body.classList.add("dark-theme");
-      themeToggle.checked = true;
+    window.addEventListener("DOMContentLoaded", () => {
+      const savedTheme = localStorage.getItem("theme");
+      if (savedTheme === "dark") {
+        document.body.classList.add("dark-theme");
+        themeToggle.checked = true;
+      }
+    });
+  </script>
+  <script>
+  async function loadLessons() {
+    try {
+      const res = await fetch('/api/lessons');
+      if (!res.ok) throw new Error('HTTP error ' + res.status);
+      const data = await res.json();
+      const select = document.getElementById('lesson_code');
+      const lessons = Array.isArray(data.lessons) ? data.lessons : data;
+      if (!Array.isArray(lessons)) throw new Error('Format data salah');
+      lessons.forEach(lesson => {
+        const opt = document.createElement('option');
+        const code = lesson.code || lesson.lesson_id || lesson.id;
+        opt.value = code;
+        opt.textContent = `${lesson.title || lesson.nama || code} (${code})`;
+        select.appendChild(opt);
+      });
+    } catch (err) {
+      console.error('❌ Failed to load lessons:', err);
     }
-</script>
-<script>
-async function loadLessons() {
-  try {
-    const res = await fetch('/api/lessons');
-    const data = await res.json();
-    const select = document.getElementById('lesson_code');
-    if (!Array.isArray(data)) throw new Error('Format data salah');
-    data.forEach(lesson => {
-      const opt = document.createElement('option');
-      opt.value = lesson.code;
-      opt.textContent = `${lesson.title} (${lesson.code})`;
-      select.appendChild(opt);
-  } catch (err) {
-    console.error('❌ Failed to load lessons:', err);
   }
-}
 
-async function loadLessonAccessList() {
-  try {
-    const res = await fetch('/api/akses-lesson');
-    const data = await res.json();
-    const tbody = document.querySelector('#lesson-access-table tbody');
-    tbody.innerHTML = '';
-    data.forEach(row => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td>${row.nama} (${row.cid})</td>
-        <td>${row.title}</td>
-        <td>${row.code}</td>
-        <td>${row.status}</td>
-        <td><button onclick="hapusAksesLesson('${row.cid}', '${row.code}')">❌ Hapus</button></td>
-      `;
-      tbody.appendChild(tr);
-  } catch (err) {
-    console.error('❌ Gagal memuat daftar akses lesson:', err);
+  async function loadLessonAccessList() {
+    try {
+      const res = await fetch('/api/akses-lesson');
+      if (!res.ok) throw new Error('HTTP error ' + res.status);
+      const data = await res.json();
+      const tbody = document.querySelector('#lesson-access-table tbody');
+      tbody.innerHTML = '';
+      const list = Array.isArray(data.data) ? data.data : data;
+      if (!Array.isArray(list)) throw new Error('Format data salah');
+      list.forEach(row => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${row.nama || ''} (${row.cid})</td>
+          <td>${row.title || ''}</td>
+          <td>${row.code}</td>
+          <td>${row.status || ''}</td>
+          <td><button onclick="hapusAksesLesson('${row.cid}', '${row.code}')">❌ Hapus</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+    } catch (err) {
+      console.error('❌ Gagal memuat daftar akses lesson:', err);
+    }
   }
-}
 
 async function hapusAksesLesson(cid, code) {
   if (!confirm(`Hapus akses lesson ${code} dari ${cid}?`)) return;
@@ -508,20 +518,28 @@ async function hapusAksesLesson(cid, code) {
 
 document.addEventListener('DOMContentLoaded', () => {
   // Populate student select for assign lesson
-  fetch('/api/semua-murid').then(res => res.json()).then(list => {
-    const select = document.getElementById('assign_lesson_uid');
-    if (select) {
-      select.innerHTML = '<option value="">Pilih Murid</option>';
-      list.forEach(m => {
-        const opt = document.createElement('option');
-        opt.value = m.cid;
-        opt.textContent = `${m.nama} (${m.cid})`;
-        select.appendChild(opt);
-    }
-  }).catch(err => {
-    console.error('❌ Failed to load students:', err);
+  fetch('/api/semua-murid')
+    .then(res => res.json())
+    .then(list => {
+      const select = document.getElementById('assign_lesson_uid');
+      if (select) {
+        select.innerHTML = '<option value="">Pilih Murid</option>';
+        list.forEach(m => {
+          const id = m.cid || m.uid || '';
+          const opt = document.createElement('option');
+          opt.value = id;
+          opt.textContent = `${m.nama} (${id})`;
+          select.appendChild(opt);
+        });
+      }
+    })
+    .catch(err => {
+      console.error('❌ Failed to load students:', err);
+    });
+
   loadLessons();
   loadLessonAccessList();
+
   // Handle assign lesson form submission
   const form = document.getElementById('form-assign-lesson');
   if (form) {
@@ -536,19 +554,22 @@ document.addEventListener('DOMContentLoaded', () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ cid, lesson })
+        });
         if (res.ok) {
           if (status) status.textContent = '✅ Akses lesson berhasil ditambahkan.';
           form.reset();
           loadLessonAccessList();
         } else {
-      const data = await res.json();
-      if (status) status.textContent = '❌ ' + (data.error || 'Gagal assign lesson');
+          const data = await res.json();
+          if (status) status.textContent = '❌ ' + (data.error || 'Gagal assign lesson');
         }
       } catch (err) {
         console.error(err);
         if (status) status.textContent = '❌ Gagal assign lesson';
       }
-    }
-  </script>
+    });
+  }
+});
+</script>
 </body>
 </html>

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -1166,21 +1166,6 @@ app.post('/api/karya-anak/highlight', async (req, res) => {
   }
 });
 
-// Default route ke index.html
-app.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, 'public/index.html'));
-});
-
-// Fallback 404
-app.use((req, res) => {
-    res.status(404).send('404 Not Found');
-});
-
-// Start server
-http.listen(PORT, () => {
-    console.log(`🚀 Server jalan di http://localhost:${PORT}`);
-});
-
 // POST /api/assign-lesson - assign akses lesson ke akun berdasarkan cid
 app.post('/api/assign-lesson', async (req, res) => {
   const { cid, lesson } = req.body;
@@ -1201,6 +1186,55 @@ app.post('/api/assign-lesson', async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     console.error('❌ Error assign lesson:', err);
+    res.status(500).json({ success: false, error: 'Server error' });
+  }
+});
+
+// GET /api/akses-lesson - daftar semua akses lesson
+app.get('/api/akses-lesson', async (req, res) => {
+  try {
+    const akunSnap = await db.collection('akun').get();
+    const lessonSnap = await db.collection('lessons').get();
+    const lessonMap = {};
+    lessonSnap.forEach(d => {
+      const val = d.data();
+      const code = d.id;
+      lessonMap[code] = val.title || val.nama || '';
+    });
+    const result = [];
+    akunSnap.forEach(doc => {
+      const data = doc.data();
+      const akses = Array.isArray(data.akses_lesson) ? data.akses_lesson : [];
+      akses.forEach(code => {
+        result.push({
+          cid: data.cid || doc.id,
+          nama: data.nama || '',
+          code,
+          title: lessonMap[code] || '',
+          status: data.status || ''
+        });
+      });
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('❌ Error get akses lesson:', err);
+    res.status(500).json([]);
+  }
+});
+
+// DELETE /api/akses-lesson/:cid/:lesson - hapus akses lesson dari akun
+app.delete('/api/akses-lesson/:cid/:lesson', async (req, res) => {
+  const { cid, lesson } = req.params;
+  if (!cid || !lesson) {
+    return res.status(400).json({ success: false, error: 'Data tidak lengkap' });
+  }
+  try {
+    await db.collection('akun').doc(cid).update({
+      akses_lesson: admin.firestore.FieldValue.arrayRemove(lesson)
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('❌ Error delete akses lesson:', err);
     res.status(500).json({ success: false, error: 'Server error' });
   }
 });
@@ -1227,4 +1261,19 @@ app.post('/api/selesai-kelas', async (req, res) => {
     console.error('❌ Error kirim ke Apps Script:', err);
     res.status(500).json({ success: false, error: 'Gagal menyimpan ke Apps Script' });
   }
+});
+
+// Default route ke index.html
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public/index.html'));
+});
+
+// Fallback 404
+app.use((req, res) => {
+  res.status(404).send('404 Not Found');
+});
+
+// Start server
+http.listen(PORT, () => {
+  console.log(`🚀 Server jalan di http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- improve lesson dropdown loader and handle HTTP errors
- validate lesson access list data before rendering
- add endpoints to list and delete lesson access
- register new routes before the 404 handler
- handle both `uid` and `cid` when building student options

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687f7bd3c0e88325bdac4f65a09b847a