### PR TITLE
Fix role field default in login API

### DIFF
--- a/firebase-upload-backend/firebase_upload.js
+++ b/firebase-upload-backend/firebase_upload.js
@@ -940,10 +940,13 @@ app.get("/api/get-role-by-uid", async (req, res) => {
 
     const akunData = akunSnap.data();
 
+    // Default to 'murid' if role field is missing for backward compatibility
+    const role = akunData.role || "murid";
+
     return res.json({
       uid,
       cid: akunData.cid || "",
-      role: akunData.role || "",
+      role,
       nama: akunData.nama || "",
       email: akunData.email || "",
     });


### PR DESCRIPTION
## Summary
- default missing role to `murid` when fetching role by UID

## Testing
- `npm test` (fails: no test specified)
- `npm test` in magicmirror-node (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_688896aead648325930cf391fc49a626