### PR TITLE
feat: mirror class progress data

### DIFF
--- a/magicmirror-node/package.json
+++ b/magicmirror-node/package.json
@@ -16,7 +16,8 @@
     "path": "^0.12.7",
     "socket.io": "^4.8.1",
     "googleapis": "^130.0.0",
-    "firebase-admin": "^11.10.1"
+    "firebase-admin": "^11.10.1",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -9,6 +9,16 @@ const path = require('path');
 const { google } = require('googleapis');
 const uploadModulRouter = require('./uploadModul');
 const admin = require('firebase-admin');
+const fetch = require('node-fetch');
+
+async function postToGAS(tabName, dataArray) {
+  const res = await fetch(`${process.env.WEB_APP_URL}?action=mirrorData`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tab: tabName, data: dataArray })
+  });
+  return await res.json();
+}
 
 // POST /api/assign-murid-ke-kelas - assign murid ke kelas/lesson
 app.post('/api/assign-murid-ke-kelas', async (req, res) => {
@@ -409,6 +419,11 @@ app.get('/api/lessons', async (req, res) => {
       ...doc.data()
     }));
     res.json({ success: true, lessons: data });
+    try {
+      await postToGAS('EL_LESSONS_LIST', data);
+    } catch (err) {
+      console.error('Mirror LESSONS_LIST gagal:', err);
+    }
   } catch (err) {
     console.error('❌ Error ambil daftar lessons:', err);
     res.status(500).json({ success: false, error: 'Server error' });
@@ -524,6 +539,11 @@ app.get('/api/kelas', async (req, res) => {
       };
     });
     res.json({ success: true, data });
+    try {
+      await postToGAS('EL_CLASS_LIST', data);
+    } catch (err) {
+      console.error('Mirror CLASS_LIST gagal:', err);
+    }
   } catch (err) {
     console.error('❌ Error get kelas:', err);
     res.status(500).json({ success: false, error: 'Server error' });
@@ -1067,6 +1087,11 @@ app.get('/api/progress-murid', async (req, res) => {
     }
 
     res.json(hasil);
+    try {
+      await postToGAS('EL_STUDENT_PROGRESS', hasil);
+    } catch (err) {
+      console.error('Mirror STUDENT_PROGRESS gagal:', err);
+    }
   } catch (err) {
     console.error('❌ Error get progress murid:', err);
     res.status(500).json([]);
@@ -1167,8 +1192,12 @@ app.get('/api/karya-semua', async (req, res) => {
         status
       });
     }
-
     res.json(hasilGabung);
+    try {
+      await postToGAS('EL_STUDENT_WORKS', hasilGabung);
+    } catch (err) {
+      console.error('Mirror STUDENT_WORKS gagal:', err);
+    }
   } catch (err) {
     console.error('❌ Gagal get karya_semua:', err);
     res.status(500).json({ error: 'Failed to fetch' });


### PR DESCRIPTION
## Summary
- add node-fetch helper to send mirroring requests to Apps Script
- mirror class list, lessons, student progress, and student works APIs to GAS

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68906ed0fbf48325a1f92b420adf1948