### PR TITLE
feat: add mirror-all data endpoint

### DIFF
--- a/magicmirror-node/public/elearn/moderator.html
+++ b/magicmirror-node/public/elearn/moderator.html
@@ -482,6 +482,10 @@
           </div>
         </div>
       </section>
+      <section class="section-mirror-login section-spacing" style="margin-bottom: 30px;">
+        <button id="mirrorLoginBtn">Mirror Login Data</button>
+        <div id="mirrorLoginStatus"></div>
+      </section>
     </main>
   </div>
   <script>
@@ -502,6 +506,7 @@
     loadAllStudents();
     document.getElementById('form-add-class').addEventListener('submit', addClass);
     document.getElementById('form-add-student').addEventListener('submit', addStudent);
+    document.getElementById('mirrorLoginBtn').addEventListener('click', mirrorLoginData);
 
     async function loadClasses() {
       try {
@@ -531,6 +536,19 @@
         document.getElementById('stat-guru').textContent = guruSet.size;
       } catch (err) {
         console.error(err);
+      }
+    }
+
+    async function mirrorLoginData() {
+      const statusEl = document.getElementById('mirrorLoginStatus');
+      statusEl.textContent = '⏳ Mirroring...';
+      try {
+        const res = await fetch('/api/mirror-login-data');
+        const json = await res.json();
+        statusEl.textContent = '✅ Mirroring selesai: ' + JSON.stringify(json);
+      } catch (err) {
+        console.error(err);
+        statusEl.textContent = '❌ Gagal mirror login data';
       }
     }
 

--- a/magicmirror-node/public/elearn/sidebar-mod.html
+++ b/magicmirror-node/public/elearn/sidebar-mod.html
@@ -60,6 +60,10 @@
           <li><a href="progress-tracking.html"><i class="fas fa-chart-line"></i><span class="sidebar-label">Student Progress</span></a></li>
           <li><a href="student-works.html"><i class="fas fa-paint-brush"></i><span class="sidebar-label">Student Works</span></a></li>
           <li><a href="activity-reports.html"><i class="fas fa-file-alt"></i><span class="sidebar-label">Activity Reports</span></a></li>
+          <li style="padding:8px 0 0 10px;">
+            <button id="mirror-all-btn" style="padding:6px 12px;border:none;background:#0069d9;color:#fff;border-radius:6px;cursor:pointer;">Mirror All Now</button>
+            <div id="mirror-all-status" style="padding-top:4px;color:#fff;"></div>
+          </li>
         </ul>
         <hr class="sidebar-divider">
       </div>
@@ -92,3 +96,17 @@
     </button>
   </aside>
 </div>
+<script>
+document.getElementById('mirror-all-btn')?.addEventListener('click', async () => {
+  const statusEl = document.getElementById('mirror-all-status');
+  if (statusEl) statusEl.textContent = '⏳ Mirroring...';
+  try {
+    const res = await fetch('/api/mirror-all');
+    await res.json();
+    if (statusEl) statusEl.textContent = '✅ Mirror all success';
+  } catch (err) {
+    console.error('Mirror all data failed:', err);
+    if (statusEl) statusEl.textContent = '❌ Mirror all failed';
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- add postAllToGAS helper and data gather functions
- create `/api/mirror-all` endpoint to send multiple datasets to GAS at once
- add "Mirror All Now" button in moderator sidebar
- add `/api/mirror-login-data` endpoint to push Firebase accounts to `EL_MASTER_USER`
- include mirror-login button on moderator dashboard

## Testing
- `npm test` (fails: Missing script)
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_6890810b8f0c83258522224036233a8c