### PR TITLE
Fix student dropdown and class student listing

### DIFF
--- a/magicmirror-node/public/elearn/class.html
+++ b/magicmirror-node/public/elearn/class.html
@@ -517,11 +517,14 @@
           console.error('Format response tidak sesuai:', json);
         }
         muridList.forEach(murid => {
+          const cid = murid.cid || murid.uid || '';
+          const nama = murid.nama || murid.name || '';
+          const email = murid.email || '';
           const tr = document.createElement('tr');
           tr.innerHTML = `
-            <td data-label="CID">${murid.cid}</td>
-            <td data-label="Nama"><a href="/elearn/student-profile.html?cid=${murid.cid}">${murid.nama}</a></td>
-            <td data-label="Email">${murid.email}</td>`;
+            <td data-label="CID">${cid}</td>
+            <td data-label="Nama"><a href="/elearn/student-profile.html?cid=${cid}">${nama}</a></td>
+            <td data-label="Email">${email}</td>`;
           tbody.appendChild(tr);
         });
       } catch (err) {
@@ -533,13 +536,18 @@
       try {
         const res = await fetch('/api/semua-murid');
         const json = await res.json();
-        const list = Array.isArray(json.data) ? json.data : [];
+        const list = Array.isArray(json.data) ? json.data : (Array.isArray(json) ? json : []);
         const studentSelect = document.getElementById('student-select');
         studentSelect.innerHTML = '<option value="" disabled selected>Pilih Murid</option>';
         list.forEach(murid => {
+          const uid = murid.uid || murid.cid || '';
+          const cid = murid.cid || '';
+          const nama = murid.nama || murid.name || cid || uid;
+          const email = murid.email || '';
           const option = document.createElement('option');
-          option.value = murid.cid;
-          option.textContent = murid.nama + ' (' + murid.email + ')';
+          option.value = uid; // gunakan uid dokumen untuk assign
+          option.dataset.cid = cid;
+          option.textContent = `${nama} (${email})`;
           studentSelect.appendChild(option);
         });
       } catch (err) {
@@ -577,34 +585,41 @@
     const assignForm = document.getElementById('assign-form');
     assignForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const cid = document.getElementById('student-select').value;
+      const uid = document.getElementById('student-select').value;
       const kelas_id = document.getElementById('class-select').value;
       const statusEl = document.getElementById('assign-status');
       statusEl.textContent = '';
-      if (!cid || !kelas_id) {
+      if (!uid || !kelas_id) {
         statusEl.textContent = 'Silakan pilih murid dan kelas.';
         return;
       }
-      try {
-        const res = await fetch('/api/assign-student-to-class', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ cid, kelas_id })
-        });
-        if (res.ok) {
-          statusEl.style.color = 'green';
-          statusEl.textContent = 'Berhasil assign/move murid ke kelas.';
-          if (kelas_id === currentSelectedClassId) {
-            loadStudents(kelas_id);
+        try {
+          const res = await fetch('/api/assign-murid-ke-kelas', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ uid, kelas_id })
+          });
+          const raw = await res.text();
+          if (res.ok) {
+            statusEl.style.color = 'green';
+            statusEl.textContent = 'Berhasil assign/move murid ke kelas.';
+            if (kelas_id === currentSelectedClassId) {
+              loadStudents(kelas_id);
+            }
+          } else {
+            let message = res.statusText;
+            try {
+              const errorData = JSON.parse(raw);
+              message = errorData.message || errorData.error || message;
+            } catch (e) {
+              if (raw) message = raw;
+            }
+            statusEl.style.color = 'red';
+            statusEl.textContent = 'Gagal assign murid: ' + message;
           }
-        } else {
-          const errorData = await res.json();
-          statusEl.style.color = 'red';
-          statusEl.textContent = 'Gagal assign murid: ' + (errorData.message || res.statusText);
-        }
-      } catch (err) {
+        } catch (err) {
         statusEl.style.color = 'red';
         statusEl.textContent = 'Error saat assign murid.';
         console.error(err);

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -11,6 +11,10 @@ const uploadModulRouter = require('./uploadModul');
 const admin = require('firebase-admin');
 const fetch = require('node-fetch');
 
+// Apply middleware early so body parsing is available for all routes
+app.use(cors());
+app.use(express.json({ limit: '10mb' })); // handle large JSON bodies
+
 async function postToGAS(tabName, dataArray) {
   const GAS_URL = process.env.WEB_APP_URL || 'https://script.google.com/macros/s/AKfycbynFv8gTnczc7abTL5Olq_sKmf1e0y6w9z_KBTKETK8i6NaGd941Cna4QVnoujoCsMdvA/exec';
   if (!GAS_URL.startsWith('http')) {
@@ -52,15 +56,24 @@ async function postAllToGAS(datasets) {
 
 // POST /api/assign-murid-ke-kelas - assign murid ke kelas/lesson
 app.post('/api/assign-murid-ke-kelas', async (req, res) => {
-  const { uid, kelas_id } = req.body;
+  // Safely extract body fields in case body parsing fails
+  const { uid, kelas_id } = req.body || {};
   if (!uid || !kelas_id) {
     return res.status(400).json({ success: false, error: 'Data tidak lengkap' });
   }
   try {
-    const muridRef = db.collection('murid').doc(uid);
-    const muridSnap = await muridRef.get();
+    let targetUid = uid;
+    let muridRef = db.collection('murid').doc(targetUid);
+    let muridSnap = await muridRef.get();
+    // Jika tidak ditemukan, coba cari berdasarkan field cid
     if (!muridSnap.exists) {
-      return res.status(404).json({ success: false, error: 'Murid tidak ditemukan' });
+      const byCid = await db.collection('murid').where('cid', '==', uid).limit(1).get();
+      if (byCid.empty) {
+        return res.status(404).json({ success: false, error: 'Murid tidak ditemukan' });
+      }
+      muridSnap = byCid.docs[0];
+      targetUid = muridSnap.id;
+      muridRef = db.collection('murid').doc(targetUid);
     }
 
     // Tambahkan kelas_id ke array akses_lesson murid
@@ -73,7 +86,7 @@ app.post('/api/assign-murid-ke-kelas', async (req, res) => {
     const kelasRef = db.collection('kelas').doc(kelas_id);
     await kelasRef.set({ kelas_id }, { merge: true });
     await kelasRef.update({
-      murid: admin.firestore.FieldValue.arrayUnion(uid)
+      murid: admin.firestore.FieldValue.arrayUnion(targetUid)
     });
 
     res.json({ success: true });
@@ -195,8 +208,7 @@ async function getRewardHistory() {
   return snap.docs.map(d => ({ id: d.id, ...d.data() }));
 }
 
-app.use(cors());
-app.use(express.json({ limit: '10mb' })); // untuk terima JSON besar (seperti foto)
+// Static assets and additional routers
 app.use('/generated_lessons', express.static(path.join(__dirname, '..', 'generated_lessons')));
 app.use(uploadModulRouter);
 


### PR DESCRIPTION
## Summary
- show student names and emails when viewing class roster or selecting a student
- send selected student to proper endpoint when assigning them to a class
- ensure assign-student endpoint parses JSON bodies and handle non-JSON error responses in the UI
- handle assigning by UID and fall back to lookup by CID if needed

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891d35ca0288325b8e9736d782affbb