### PR TITLE
Fix student dropdown and class student listing

### DIFF
--- a/magicmirror-node/public/elearn/class.html
+++ b/magicmirror-node/public/elearn/class.html
@@ -479,8 +479,15 @@
                   loadClasses();
                   loadClassOptions();
                 } else {
-                  const errData = await res.json();
-                  alert('Gagal menghapus kelas: ' + (errData.message || res.statusText));
+                  const text = await res.text();
+                  let msg = '';
+                  try {
+                    const errJson = JSON.parse(text);
+                    msg = errJson.message || errJson.error || '';
+                  } catch (e) {
+                    msg = text;
+                  }
+                  alert('Gagal menghapus kelas: ' + (msg || res.statusText));
                 }
               } catch (err) {
                 alert('Terjadi kesalahan saat menghapus kelas.');
@@ -517,11 +524,14 @@
           console.error('Format response tidak sesuai:', json);
         }
         muridList.forEach(murid => {
+          const cid = murid.cid || murid.uid || '';
+          const nama = murid.nama || murid.name || '';
+          const email = murid.email || '';
           const tr = document.createElement('tr');
           tr.innerHTML = `
-            <td data-label="CID">${murid.cid}</td>
-            <td data-label="Nama"><a href="/elearn/student-profile.html?cid=${murid.cid}">${murid.nama}</a></td>
-            <td data-label="Email">${murid.email}</td>`;
+            <td data-label="CID">${cid}</td>
+            <td data-label="Nama"><a href="/elearn/student-profile.html?cid=${cid}">${nama}</a></td>
+            <td data-label="Email">${email}</td>`;
           tbody.appendChild(tr);
         });
       } catch (err) {
@@ -533,13 +543,18 @@
       try {
         const res = await fetch('/api/semua-murid');
         const json = await res.json();
-        const list = Array.isArray(json.data) ? json.data : [];
+        const list = Array.isArray(json.data) ? json.data : (Array.isArray(json) ? json : []);
         const studentSelect = document.getElementById('student-select');
         studentSelect.innerHTML = '<option value="" disabled selected>Pilih Murid</option>';
         list.forEach(murid => {
+          const uid = murid.uid || murid.cid || '';
+          const cid = murid.cid || '';
+          const nama = murid.nama || murid.name || cid || uid;
+          const email = murid.email || '';
           const option = document.createElement('option');
-          option.value = murid.cid;
-          option.textContent = murid.nama + ' (' + murid.email + ')';
+          option.value = uid; // gunakan uid dokumen untuk assign
+          option.dataset.cid = cid;
+          option.textContent = `${nama} (${email})`;
           studentSelect.appendChild(option);
         });
       } catch (err) {
@@ -577,34 +592,41 @@
     const assignForm = document.getElementById('assign-form');
     assignForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const cid = document.getElementById('student-select').value;
+      const uid = document.getElementById('student-select').value;
       const kelas_id = document.getElementById('class-select').value;
       const statusEl = document.getElementById('assign-status');
       statusEl.textContent = '';
-      if (!cid || !kelas_id) {
+      if (!uid || !kelas_id) {
         statusEl.textContent = 'Silakan pilih murid dan kelas.';
         return;
       }
-      try {
-        const res = await fetch('/api/assign-student-to-class', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ cid, kelas_id })
-        });
-        if (res.ok) {
-          statusEl.style.color = 'green';
-          statusEl.textContent = 'Berhasil assign/move murid ke kelas.';
-          if (kelas_id === currentSelectedClassId) {
-            loadStudents(kelas_id);
+        try {
+          const res = await fetch('/api/assign-murid-ke-kelas', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ uid, kelas_id })
+          });
+          const raw = await res.text();
+          if (res.ok) {
+            statusEl.style.color = 'green';
+            statusEl.textContent = 'Berhasil assign/move murid ke kelas.';
+            if (kelas_id === currentSelectedClassId) {
+              loadStudents(kelas_id);
+            }
+          } else {
+            let message = res.statusText;
+            try {
+              const errorData = JSON.parse(raw);
+              message = errorData.message || errorData.error || message;
+            } catch (e) {
+              if (raw) message = raw;
+            }
+            statusEl.style.color = 'red';
+            statusEl.textContent = 'Gagal assign murid: ' + message;
           }
-        } else {
-          const errorData = await res.json();
-          statusEl.style.color = 'red';
-          statusEl.textContent = 'Gagal assign murid: ' + (errorData.message || res.statusText);
-        }
-      } catch (err) {
+        } catch (err) {
         statusEl.style.color = 'red';
         statusEl.textContent = 'Error saat assign murid.';
         console.error(err);


### PR DESCRIPTION
## Summary
- show student names and emails when viewing class roster or selecting a student
- send selected student to proper endpoint when assigning them to a class
- ensure assign-student endpoint parses JSON bodies and handle non-JSON error responses in the UI
- handle assigning by UID and fall back to lookup by CID if needed
- add endpoint to delete classes and handle non-JSON responses when a delete fails

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891d35ca0288325b8e9736d782affbb