### PR TITLE
Expand active lesson detection

### DIFF
--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -523,7 +523,8 @@ app.get('/api/lesson-aktif', async (req, res) => {
       const lessonSnap = await db.collection('progress_murid').doc(cid).collection('lessons').get();
       for (const l of lessonSnap.docs) {
         const data = l.data();
-        if (data.status === 'berlangsung') {
+        // Consider lessons with status 'aktif' (active) or 'berlangsung' (ongoing)
+        if (data.status === 'aktif' || data.status === 'berlangsung') {
           hasil.push({
             cid,
             nama_murid: nama,


### PR DESCRIPTION
## Summary
- Include lessons marked with `aktif` when computing the active lesson list

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68924cf1f08c8325b4dfa45ddc330e03