### PR TITLE
feat: add JSON-driven world map architecture

### DIFF
--- a/magicmirror-node/public/elearn/calistung/level/A1.html
+++ b/magicmirror-node/public/elearn/calistung/level/A1.html
@@ -894,5 +894,13 @@
         });
     })();
     </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 1');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A2.html
+++ b/magicmirror-node/public/elearn/calistung/level/A2.html
@@ -278,5 +278,13 @@ document.querySelectorAll(".color-code div").forEach((el) => {
   </script>
   <button id="checkButton" class="clay-button">Periksa Jawaban</button>
   <div id="result" style="margin-top: 15px; font-weight: bold;"></div>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 2');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A3.html
+++ b/magicmirror-node/public/elearn/calistung/level/A3.html
@@ -157,5 +157,13 @@
       }
     });
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 3');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A4a.html
+++ b/magicmirror-node/public/elearn/calistung/level/A4a.html
@@ -268,5 +268,13 @@
       }).join('');
     }
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 4');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A5.html
+++ b/magicmirror-node/public/elearn/calistung/level/A5.html
@@ -166,5 +166,13 @@
       }
     });
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 5');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B1.html
+++ b/magicmirror-node/public/elearn/calistung/level/B1.html
@@ -256,5 +256,13 @@ document.getElementById('checkButton').addEventListener('click', () => {
   }
 });
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 6');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B2.html
+++ b/magicmirror-node/public/elearn/calistung/level/B2.html
@@ -242,5 +242,13 @@ document.addEventListener('DOMContentLoaded', function () {
   createGrid();
 });
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 7');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C1.html
+++ b/magicmirror-node/public/elearn/calistung/level/C1.html
@@ -159,5 +159,13 @@
     </svg>
   `;
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 8');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C2.html
+++ b/magicmirror-node/public/elearn/calistung/level/C2.html
@@ -145,5 +145,13 @@
       result.style.color = allCorrect ? 'green' : 'red';
     });
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 9');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D1.html
+++ b/magicmirror-node/public/elearn/calistung/level/D1.html
@@ -264,5 +264,13 @@
     });
   })();
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 10');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D2.html
+++ b/magicmirror-node/public/elearn/calistung/level/D2.html
@@ -551,5 +551,13 @@
 </script>
 
 <button id="check-btn" class="clay-button">Periksa Jawaban</button>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 11');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E1.html
+++ b/magicmirror-node/public/elearn/calistung/level/E1.html
@@ -356,5 +356,13 @@
       });
     }
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 12');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E2.html
+++ b/magicmirror-node/public/elearn/calistung/level/E2.html
@@ -283,5 +283,13 @@
     // Inisialisasi
     init();
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 13');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/F1.html
+++ b/magicmirror-node/public/elearn/calistung/level/F1.html
@@ -215,5 +215,13 @@
 
   function toast(msg){ document.getElementById('toast').textContent = msg; }
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 14');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G1.html
+++ b/magicmirror-node/public/elearn/calistung/level/G1.html
@@ -207,5 +207,13 @@
     // after render, normalize stored answers
     setTimeout(normalizeExpected, 0);
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 15');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G2.html
+++ b/magicmirror-node/public/elearn/calistung/level/G2.html
@@ -253,5 +253,13 @@
   newBtn.addEventListener('click', ()=> init(true));
 })();
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 16');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I1.html
+++ b/magicmirror-node/public/elearn/calistung/level/I1.html
@@ -186,5 +186,13 @@
       }
     }
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 17');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I2.html
+++ b/magicmirror-node/public/elearn/calistung/level/I2.html
@@ -396,5 +396,13 @@
     // Recompute line anchors on resize
     window.addEventListener('resize', ()=>{ layoutArc(); computePositions(); drawPuzzleLines(); });
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 18');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J1.html
+++ b/magicmirror-node/public/elearn/calistung/level/J1.html
@@ -221,5 +221,13 @@
   makePuzzles(6);
 })();
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 19');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J2a.html
+++ b/magicmirror-node/public/elearn/calistung/level/J2a.html
@@ -288,5 +288,13 @@
   }
 })();
 </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 20');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J3.html
+++ b/magicmirror-node/public/elearn/calistung/level/J3.html
@@ -251,5 +251,13 @@
     puzzles = phrases.slice();
     render();
   </script>
+<script type="module">
+  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
+  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
+    markCompletedLocal('calistung','Level 21');
+    alert('Progres tersimpan! Kembali ke map.');
+    window.location = '/elearn/worlds/calistung/index.html';
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/portal.html
+++ b/magicmirror-node/public/elearn/portal.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Edu Portal — 9 Worlds</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/elearn/worlds/styles.css">
+</head>
+<body class="portal-body">
+  <header class="portal-header">
+    <h1>🌍 Choose Your World</h1>
+    <p>Pilih dunia belajar kamu. Progres & badge akan tersimpan otomatis.</p>
+  </header>
+
+  <main class="portal-grid" id="worldGrid"></main>
+
+  <script>
+    async function loadWorlds(){
+      const res = await fetch('/elearn/worlds/worlds.json');
+      const data = await res.json();
+      const grid = document.getElementById('worldGrid');
+      grid.innerHTML = data.worlds.map(w=>`
+        <article class="portal-card" data-entry="${w.entry}">
+          <div class="portal-cover" style="background-image:url('${w.cover || "/elearn/img/map/worldmap3.webp"}')"></div>
+          <div class="portal-meta">
+            <h3>${w.name}</h3>
+            <div class="portal-progress" data-world="${w.id}">
+              <span class="ring" title="progress"></span>
+              <small>loading...</small>
+            </div>
+          </div>
+        </article>
+      `).join('');
+
+      // klik kartu
+      grid.querySelectorAll('.portal-card').forEach(card=>{
+        card.addEventListener('click', ()=>{
+          const entry = card.dataset.entry;
+          if (entry) window.location = entry;
+        });
+      });
+
+      // progress (dummy localStorage; bisa ganti Firestore)
+      grid.querySelectorAll('.portal-progress').forEach(el=>{
+        const key = `progress:${el.dataset.world}`;
+        const raw = localStorage.getItem(key);
+        const pct = raw ? JSON.parse(raw).percent||0 : 0;
+        el.querySelector('small').textContent = `${pct}%`;
+        el.querySelector('.ring').style.setProperty('--pct', pct);
+      });
+    }
+    loadWorlds();
+  </script>
+</body>
+</html>

--- a/magicmirror-node/public/elearn/sidebar-mod.html
+++ b/magicmirror-node/public/elearn/sidebar-mod.html
@@ -90,6 +90,10 @@
         <li><a href="/elearn/map.html"><i class="fas fa-school"></i> <span class="sidebar-label">School</span></a></li>
         <hr class="sidebar-divider">
       </div>
+          <div class="menu-group">
+        <li><a href="/elearn/portal.html">🌍 Worlds</a></li>
+        <hr class="sidebar-divider">
+      </div>
     </nav>
     <div class="menu-group">
       <a href="#" id="logout-btn"><i class="fas fa-sign-out-alt"></i> <span class="sidebar-label">Logout</span></a>

--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -9,6 +9,7 @@
       <span class="material-icons icon icon-emboss">menu_book</span>
       <span>Coding Lab</span>
     </a>
+    <a href="/elearn/portal.html">🌍 Worlds</a>
     <a href="/elearn/murid.html">
       <span class="material-icons icon icon-emboss">assignment</span>
       <span>Free Trial</span>

--- a/magicmirror-node/public/elearn/worlds/calistung/config.json
+++ b/magicmirror-node/public/elearn/worlds/calistung/config.json
@@ -1,0 +1,62 @@
+{
+  "meta": {
+    "id": "calistung",
+    "name": "Calistung",
+    "background": "/elearn/img/map/worldmap3.webp"
+  },
+  "routes": {
+    "Level 1":  "/elearn/calistung/level/A1.html",
+    "Level 2":  "/elearn/calistung/level/A2.html",
+    "Level 3":  "/elearn/calistung/level/A3.html",
+    "Level 4":  "/elearn/calistung/level/A4a.html",
+    "Level 5":  "/elearn/calistung/level/A5.html",
+    "Level 6":  "/elearn/calistung/level/B1.html",
+    "Level 7":  "/elearn/calistung/level/B2.html",
+    "Level 8":  "/elearn/calistung/level/C1.html",
+    "Level 9":  "/elearn/calistung/level/C2.html",
+    "Level 10": "/elearn/calistung/level/D1.html",
+    "Level 11": "/elearn/calistung/level/D2.html",
+    "Level 12": "/elearn/calistung/level/E1.html",
+    "Level 13": "/elearn/calistung/level/E2.html",
+    "Level 14": "/elearn/calistung/level/F1.html",
+    "Level 15": "/elearn/calistung/level/G1.html",
+    "Level 16": "/elearn/calistung/level/G2.html",
+    "Level 17": "/elearn/calistung/level/I1.html",
+    "Level 18": "/elearn/calistung/level/I2.html",
+    "Level 19": "/elearn/calistung/level/J1.html",
+    "Level 20": "/elearn/calistung/level/J2a.html",
+    "Level 21": "/elearn/calistung/level/J3.html"
+  },
+  "nodes": [
+    { "label":"Level 1",  "x":"27%", "y":"15%" },
+    { "label":"Level 2",  "x":"38%", "y":"19%" },
+    { "label":"Level 3",  "x":"50%", "y":"15%" },
+    { "label":"Level 4",  "x":"60%", "y":"20%" },
+    { "label":"Level 5",  "x":"72%", "y":"19%" },
+    { "label":"Level 6",  "x":"72%", "y":"33%" },
+    { "label":"Level 7",  "x":"78%", "y":"43%" },
+    { "label":"Level 8",  "x":"88%", "y":"55%" },
+    { "label":"Level 9",  "x":"95%", "y":"74%" },
+    { "label":"Level 10", "x":"90%", "y":"94%" },
+    { "label":"Level 11", "x":"63%", "y":"85%" },
+    { "label":"Level 12", "x":"42%", "y":"88%" },
+    { "label":"Level 13", "x":"12%", "y":"79%" },
+    { "label":"Level 14", "x":"10%", "y":"54%" },
+    { "label":"Level 15", "x":"25%", "y":"39%" },
+    { "label":"Level 16", "x":"30%", "y":"65%" },
+    { "label":"Level 17", "x":"65%", "y":"65%" },
+    { "label":"Level 18", "x":"53%", "y":"55%" },
+    { "label":"Level 19", "x":"43%", "y":"43%" },
+    { "label":"Level 20", "x":"56.6%", "y":"36%", "type":"boss" },
+    { "label":"Level 21", "x":"57%", "y":"30%",  "type":"finish" }
+  ],
+  "unlockRules": [
+    { "target":"Level 2",  "requires":["Level 1"] },
+    { "target":"Level 3",  "requires":["Level 2"] },
+    { "target":"Level 4",  "requires":["Level 3"] }
+  ],
+  "rewards": {
+    "Level 5":  { "coins": 10, "badge": "reader-bronze" },
+    "Level 10": { "coins": 20, "badge": "math-silver" }
+  }
+}

--- a/magicmirror-node/public/elearn/worlds/calistung/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>World — Calistung</title>
+  <link rel="stylesheet" href="/elearn/worlds/styles.css">
+</head>
+<body class="world-root">
+  <div id="worldRoot"></div>
+
+  <script type="module">
+    import { initWorld } from '/elearn/worlds/map.js';
+    // Optional: progress utils (untuk nanti dipakai di level pages)
+    import '/elearn/worlds/utils/progress.js';
+
+    initWorld({
+      rootSelector: '#worldRoot',
+      configPath: '/elearn/worlds/calistung/config.json'
+    });
+  </script>
+</body>
+</html>

--- a/magicmirror-node/public/elearn/worlds/map.js
+++ b/magicmirror-node/public/elearn/worlds/map.js
@@ -1,0 +1,99 @@
+// Reusable world map renderer
+export async function initWorld({ rootSelector = '#worldRoot', configPath }) {
+  const root = document.querySelector(rootSelector);
+  if (!root) throw new Error('world root not found');
+
+  const cfgRes = await fetch(configPath);
+  const cfg = await cfgRes.json();
+
+  root.innerHTML = `
+    <div class="world-topbar">
+      <a href="/elearn/portal.html">⟵ Portal</a>
+      <h2>${cfg.meta?.name || 'World'}</h2>
+      <div></div>
+    </div>
+    <div class="map-container">
+      <img class="world-map" src="${cfg.meta?.background}" alt="${cfg.meta?.name||'World'}">
+      <div class="arrow-flow" style="left:0;top:0"></div>
+    </div>
+  `;
+
+  const map = root.querySelector('.map-container');
+
+  // Render nodes
+  cfg.nodes.forEach(n => {
+    const el = document.createElement('div');
+    el.className = 'map-node';
+    el.style.left = n.x;
+    el.style.top = n.y;
+    el.dataset.label = n.label;
+    el.innerHTML = `
+      <img class="node-icon" src="/elearn/img/map/${n.type==='finish'?'icon-finish':n.type==='boss'?'icon-boss':'icon-lesson'}.png"/>
+      <span>${n.label}</span>
+    `;
+    // lock check (simple; replace with Firestore logic)
+    const rules = cfg.unlockRules?.filter(r => r.target === n.label) || [];
+    const completed = getCompletedLocal(cfg.meta.id); // from progress.js
+    const unlocked = rules.every(r => r.requires.every(req => completed.includes(req)));
+    if (!unlocked && rules.length) {
+      const lock = document.createElement('div');
+      lock.className = 'lock-node';
+      lock.style.left = n.x;
+      lock.style.top = n.y;
+      map.appendChild(lock);
+      el.style.pointerEvents = 'none';
+      el.style.filter = 'grayscale(0.8) opacity(0.8)';
+    }
+
+    el.addEventListener('click', () => {
+      const url = cfg.routes[n.label];
+      if (url) window.location = url;
+      else alert('Level belum tersedia.');
+    });
+
+    map.appendChild(el);
+  });
+
+  // Optional badge nodes
+  if (cfg.rewards) {
+    Object.keys(cfg.rewards).forEach(lbl => {
+      const nd = cfg.nodes.find(n => n.label === lbl);
+      if (!nd) return;
+      const b = document.createElement('div');
+      b.className = 'badge-node';
+      b.style.left = nd.x;
+      b.style.top = nd.y;
+      map.appendChild(b);
+    });
+  }
+
+  // Arrow animation
+  const arrow = root.querySelector('.arrow-flow');
+  const nodes = Array.from(map.querySelectorAll('.map-node'));
+  if (nodes.length >= 2) animateArrow(arrow, nodes, map);
+}
+
+function getCenter(el, parent) {
+  const r = el.getBoundingClientRect();
+  const p = parent.getBoundingClientRect();
+  return { x: r.left + r.width/2 - p.left, y: r.top + r.height/2 - p.top };
+}
+
+function animateArrow(arrow, nodes, parent) {
+  let idx = 0;
+  function step() {
+    const from = getCenter(nodes[idx], parent);
+    const to = getCenter(nodes[(idx+1)%nodes.length], parent);
+    let t = 0;
+    function loop() {
+      t += 0.015;
+      if (t>1) t = 1;
+      arrow.style.left = (from.x + (to.x - from.x)*t) + 'px';
+      arrow.style.top  = (from.y + (to.y - from.y)*t) + 'px';
+      if (t < 1) requestAnimationFrame(loop);
+      else { idx=(idx+1)%nodes.length; setTimeout(step, 300); }
+    }
+    loop();
+  }
+  step();
+}

--- a/magicmirror-node/public/elearn/worlds/styles.css
+++ b/magicmirror-node/public/elearn/worlds/styles.css
@@ -1,0 +1,30 @@
+*{box-sizing:border-box} body{margin:0;font-family:'Baloo 2',system-ui,-apple-system}
+.portal-body{background:#0f172a;color:#fff;min-height:100vh}
+.portal-header{padding:32px 20px;text-align:center}
+.portal-header h1{margin:0 0 8px;font-size:32px}
+.portal-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:18px;padding:0 20px 40px;max-width:1200px;margin:0 auto}
+.portal-card{background:#111827;border-radius:20px;overflow:hidden;cursor:pointer;box-shadow:0 8px 24px rgba(0,0,0,.25);border:1px solid #1f2937;transition:transform .2s}
+.portal-card:hover{transform:translateY(-4px)}
+.portal-cover{height:140px;background-size:cover;background-position:center}
+.portal-meta{padding:14px 16px;display:flex;align-items:center;justify-content:space-between}
+.portal-meta h3{margin:0;font-size:18px}
+.portal-progress{display:flex;align-items:center;gap:8px}
+.portal-progress .ring{--pct:0; width:40px;height:40px;border-radius:50%;background:
+  conic-gradient(#22c55e var(--pct)*1%, #334155 0);
+  display:inline-block;position:relative}
+.portal-progress .ring::after{
+  content:"";position:absolute;inset:4px;background:#111827;border-radius:50%
+}
+.world-root{position:relative;min-height:100vh;background:#f8fafc;color:#0f172a}
+.map-container{position:relative;width:100%;max-width:1200px;margin:0 auto}
+.world-map{width:100%;display:block;border-radius:20px}
+.map-node{position:absolute;transform:translate(-50%,-50%);cursor:pointer;text-align:center;z-index:2}
+.map-node .node-icon{width:48px;height:48px;background:#fff;border-radius:16px;border:3px solid #a5b4fc;box-shadow:0 2px 10px #0002;margin-bottom:6px}
+.map-node span{display:inline-block;padding:4px 10px;border-radius:10px;background:#6366f1;color:#fff;font-weight:700;font-size:12px;opacity:.95}
+.badge-node,.lock-node{position:absolute;width:38px;height:38px;background-size:contain;background-repeat:no-repeat;z-index:3}
+.badge-node{background-image:url('/elearn/img/icon/icon-badge.png');animation:float 2.5s ease-in-out infinite}
+.lock-node{background-image:url('/elearn/img/icon/icon-lock.png')}
+@keyframes float{0%{transform:translate(-50%,-50%) translateY(0)}50%{transform:translate(-50%,-50%) translateY(-8px)}100%{transform:translate(-50%,-50%) translateY(0)}}
+.arrow-flow{position:absolute;width:30px;height:30px;background-image:url('/elearn/img/decor/arrow.png');background-size:contain;background-repeat:no-repeat;z-index:3}
+.world-topbar{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 16px;max-width:1200px;margin:10px auto}
+.world-topbar a{background:#111827;color:#fff;text-decoration:none;padding:8px 12px;border-radius:12px}

--- a/magicmirror-node/public/elearn/worlds/utils/progress.js
+++ b/magicmirror-node/public/elearn/worlds/utils/progress.js
@@ -1,0 +1,19 @@
+// Simple local progress (bisa diganti Firestore)
+export function getCompletedLocal(worldId){
+  try{
+    const raw = localStorage.getItem(`progress:${worldId}`);
+    if(!raw) return [];
+    return JSON.parse(raw).completed || [];
+  }catch(e){ return []; }
+}
+
+export function markCompletedLocal(worldId, label){
+  const key = `progress:${worldId}`;
+  const raw = localStorage.getItem(key);
+  const data = raw? JSON.parse(raw) : { completed:[], percent:0 };
+  if (!data.completed.includes(label)) data.completed.push(label);
+  // naive percent: selesai / 21 * 100
+  const total = 21;
+  data.percent = Math.min(100, Math.round(data.completed.length/total*100));
+  localStorage.setItem(key, JSON.stringify(data));
+}

--- a/magicmirror-node/public/elearn/worlds/worlds.json
+++ b/magicmirror-node/public/elearn/worlds/worlds.json
@@ -1,0 +1,13 @@
+{
+  "worlds": [
+    { "id": "calistung",      "name": "Calistung",            "theme": "pastel-garden", "cover": "/elearn/img/map/portal-calistung.webp",      "entry": "/elearn/worlds/calistung/index.html" },
+    { "id": "kinder-coder",   "name": "Kinder Coder",         "theme": "lego-lab",      "cover": "/elearn/img/map/portal-kc.webp",             "entry": "/elearn/worlds/kinder-coder/index.html" },
+    { "id": "visual-programming","name": "Visual Programming","theme": "blocky",        "cover": "/elearn/img/map/portal-vp.webp",             "entry": "/elearn/worlds/visual-programming/index.html" },
+    { "id": "python",         "name": "Python",               "theme": "neon-blue",     "cover": "/elearn/img/map/portal-python.webp",         "entry": "/elearn/worlds/python/index.html" },
+    { "id": "web",            "name": "Website Development",  "theme": "sunset",        "cover": "/elearn/img/map/portal-web.webp",            "entry": "/elearn/worlds/web/index.html" },
+    { "id": "mobile",         "name": "Mobile Apps",          "theme": "teal",          "cover": "/elearn/img/map/portal-mobile.webp",         "entry": "/elearn/worlds/mobile/index.html" },
+    { "id": "robotic",        "name": "Robotic",              "theme": "steel",         "cover": "/elearn/img/map/portal-robotic.webp",        "entry": "/elearn/worlds/robotic/index.html" },
+    { "id": "ai",             "name": "Artificial Intelligence","theme": "purple",     "cover": "/elearn/img/map/portal-ai.webp",             "entry": "/elearn/worlds/ai/index.html" },
+    { "id": "open-world",     "name": "Open World",           "theme": "open",          "cover": "/elearn/img/map/portal-openworld.webp",      "entry": "/elearn/worlds/open-world/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add portal and reusable JSON-driven world map system
- introduce Calistung world with 21 levels and progress tracking
- wire level pages and sidebars to portal entry
- use existing shared world map asset to avoid binary file

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d502fb788325af35453bfabf96b3