### PR TITLE
feat: add finish button for number levels

### DIFF
--- a/magicmirror-node/public/elearn/calistung/level/A1.html
+++ b/magicmirror-node/public/elearn/calistung/level/A1.html
@@ -994,16 +994,10 @@
         });
     })();
     </script>
-<div class="finish-bar">
-  <button id="btnSelesai" type="button" aria-label="Tandai selesai Level 1">Selesai Level 1</button>
-</div>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 1');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 1','/elearn/calistung/level/A2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A2.html
+++ b/magicmirror-node/public/elearn/calistung/level/A2.html
@@ -278,13 +278,10 @@ document.querySelectorAll(".color-code div").forEach((el) => {
   </script>
   <button id="checkButton" class="clay-button">Periksa Jawaban</button>
   <div id="result" style="margin-top: 15px; font-weight: bold;"></div>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 2');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 2','/elearn/calistung/level/A3.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A3.html
+++ b/magicmirror-node/public/elearn/calistung/level/A3.html
@@ -157,13 +157,10 @@
       }
     });
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 3');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 3','/elearn/calistung/level/A4a.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A4a.html
+++ b/magicmirror-node/public/elearn/calistung/level/A4a.html
@@ -268,13 +268,10 @@
       }).join('');
     }
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 4');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 4','/elearn/calistung/level/A5.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A5.html
+++ b/magicmirror-node/public/elearn/calistung/level/A5.html
@@ -166,13 +166,10 @@
       }
     });
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 5');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 5','/elearn/calistung/level/B1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B1.html
+++ b/magicmirror-node/public/elearn/calistung/level/B1.html
@@ -256,13 +256,10 @@ document.getElementById('checkButton').addEventListener('click', () => {
   }
 });
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 6');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 6','/elearn/calistung/level/B2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B2.html
+++ b/magicmirror-node/public/elearn/calistung/level/B2.html
@@ -242,13 +242,10 @@ document.addEventListener('DOMContentLoaded', function () {
   createGrid();
 });
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 7');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 7','/elearn/calistung/level/C1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C1.html
+++ b/magicmirror-node/public/elearn/calistung/level/C1.html
@@ -159,13 +159,10 @@
     </svg>
   `;
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 8');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 8','/elearn/calistung/level/C2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C2.html
+++ b/magicmirror-node/public/elearn/calistung/level/C2.html
@@ -145,13 +145,10 @@
       result.style.color = allCorrect ? 'green' : 'red';
     });
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 9');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 9','/elearn/calistung/level/D1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D1.html
+++ b/magicmirror-node/public/elearn/calistung/level/D1.html
@@ -264,13 +264,10 @@
     });
   })();
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 10');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 10','/elearn/calistung/level/D2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D2.html
+++ b/magicmirror-node/public/elearn/calistung/level/D2.html
@@ -551,13 +551,10 @@
 </script>
 
 <button id="check-btn" class="clay-button">Periksa Jawaban</button>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 11');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 11','/elearn/calistung/level/E1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E1.html
+++ b/magicmirror-node/public/elearn/calistung/level/E1.html
@@ -356,13 +356,10 @@
       });
     }
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 12');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 12','/elearn/calistung/level/E2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E2.html
+++ b/magicmirror-node/public/elearn/calistung/level/E2.html
@@ -283,13 +283,10 @@
     // Inisialisasi
     init();
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 13');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 13','/elearn/calistung/level/F1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/F1.html
+++ b/magicmirror-node/public/elearn/calistung/level/F1.html
@@ -215,13 +215,10 @@
 
   function toast(msg){ document.getElementById('toast').textContent = msg; }
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 14');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 14','/elearn/calistung/level/G1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G1.html
+++ b/magicmirror-node/public/elearn/calistung/level/G1.html
@@ -207,13 +207,10 @@
     // after render, normalize stored answers
     setTimeout(normalizeExpected, 0);
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 15');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 15','/elearn/calistung/level/G2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G2.html
+++ b/magicmirror-node/public/elearn/calistung/level/G2.html
@@ -253,13 +253,10 @@
   newBtn.addEventListener('click', ()=> init(true));
 })();
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 16');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 16','/elearn/calistung/level/I1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I1.html
+++ b/magicmirror-node/public/elearn/calistung/level/I1.html
@@ -186,13 +186,10 @@
       }
     }
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 17');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 17','/elearn/calistung/level/I2.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I2.html
+++ b/magicmirror-node/public/elearn/calistung/level/I2.html
@@ -396,13 +396,10 @@
     // Recompute line anchors on resize
     window.addEventListener('resize', ()=>{ layoutArc(); computePositions(); drawPuzzleLines(); });
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 18');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 18','/elearn/calistung/level/J1.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J1.html
+++ b/magicmirror-node/public/elearn/calistung/level/J1.html
@@ -221,13 +221,10 @@
   makePuzzles(6);
 })();
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 19');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 19','/elearn/calistung/level/J2a.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J2a.html
+++ b/magicmirror-node/public/elearn/calistung/level/J2a.html
@@ -288,13 +288,10 @@
   }
 })();
 </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 20');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 20','/elearn/calistung/level/J3.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J3.html
+++ b/magicmirror-node/public/elearn/calistung/level/J3.html
@@ -251,13 +251,10 @@
     puzzles = phrases.slice();
     render();
   </script>
+
 <script type="module">
-  import { markCompletedLocal } from '/elearn/worlds/utils/progress.js';
-  document.querySelector('#btnSelesai')?.addEventListener('click', ()=>{
-    markCompletedLocal('calistung','Level 21');
-    alert('Progres tersimpan! Kembali ke map.');
-    window.location = '/elearn/worlds/calistung/index.html';
-  });
+  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
+  addFinishButton('calistung','Level 21','/elearn/worlds/calistung/index.html');
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/utils/finish-button.js
+++ b/magicmirror-node/public/elearn/worlds/utils/finish-button.js
@@ -1,0 +1,38 @@
+import { markCompletedLocal } from './progress.js';
+
+const styleContent = `
+.finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+#btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer;
+  padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px;
+  box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+#btnSelesai:hover { filter: brightness(1.05); }
+#btnSelesai:active { transform: translateY(1px); }
+@media (max-width: 480px) {
+  #btnSelesai { padding: 10px 14px; font-size: 15px; }
+}
+`;
+
+function ensureStyle(){
+  if(!document.getElementById('finish-btn-style')){
+    const s=document.createElement('style');
+    s.id='finish-btn-style';
+    s.textContent=styleContent;
+    document.head.appendChild(s);
+  }
+}
+
+export function addFinishButton(worldId,label,nextUrl){
+  ensureStyle();
+  const bar=document.createElement('div');
+  bar.className='finish-bar';
+  const btn=document.createElement('button');
+  btn.id='btnSelesai';
+  btn.type='button';
+  btn.textContent=`Selesai ${label}`;
+  bar.appendChild(btn);
+  document.body.appendChild(bar);
+  btn.addEventListener('click',()=>{
+    markCompletedLocal(worldId,label);
+    window.location = nextUrl;
+  });
+}


### PR DESCRIPTION
## Summary
- add `finish-button.js` utility to inject a Selesai button and handle progress saving
- enable sequential progression through number world levels with new finish buttons

## Testing
- `npm test` (magicmirror-node) *(fails: Missing script "test")*
- `npm test` (firebase-upload-backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689bfa3761408325b0f6853631ce628f