### PR TITLE
feat: add worksheet submission for number world

### DIFF
--- a/magicmirror-node/public/elearn/common/worksheet-submit.js
+++ b/magicmirror-node/public/elearn/common/worksheet-submit.js
@@ -1,0 +1,176 @@
+(function(){
+  async function fetchUser(){
+    try{
+      const res = await fetch('/api/auth/me',{credentials:'include'});
+      if(!res.ok) return null;
+      return await res.json();
+    }catch(err){
+      return null;
+    }
+  }
+
+  function collectAnswers(){
+    const els = document.querySelectorAll('[data-answers="true"], textarea, .code-editor');
+    const arr = [];
+    els.forEach(el=>{
+      if(el.matches('[data-answers="true"]')){
+        const val = el.value || el.textContent || '';
+        if(val) arr.push(val);
+      }else if(el.tagName === 'TEXTAREA'){
+        if(el.value) arr.push(el.value);
+      }else if(el.classList.contains('code-editor')){
+        const val = el.value || el.textContent || '';
+        if(val) arr.push(val);
+      }
+    });
+    return arr.join('\n---\n');
+  }
+
+  async function capture(selector){
+    const el = document.querySelector(selector);
+    if(!el) throw new Error('container not found');
+    window.scrollTo(0,0);
+    const canvas = await html2canvas(el,{scale:1.5,useCORS:true,backgroundColor:'#fff'});
+    let dataUrl = canvas.toDataURL('image/png');
+    if(dataUrl.length > 2*1024*1024){
+      dataUrl = canvas.toDataURL('image/jpeg',0.92);
+    }
+    return dataUrl.replace(/^data:image\/\w+;base64,/,'');
+  }
+
+  function slugify(s){
+    return String(s || '').toLowerCase().replace(/\s+/g,'-').replace(/[^a-z0-9\-]/g,'');
+  }
+
+  function guessCourseIdFromPath(pathname){
+    const segs = pathname.split('/').filter(Boolean);
+    const idx = segs.indexOf('calistung');
+    const domain = idx >= 0 ? segs[idx + 1] : '';
+    if(!domain) return '';
+    const map = {
+      number: 'numbers-basic',
+      numbers: 'numbers-basic',
+      alphabet: 'alphabet-basic',
+      huruf: 'alphabet-basic',
+      python: 'python-basic',
+    };
+    return map[slugify(domain)] || `${slugify(domain)}-basic`;
+  }
+
+  function guessLessonIdFromPath(pathname){
+    const patterns = [
+      /L(\d+)\.html$/i,
+      /alpha(\d+)\.html$/i,
+      /level[-_]?(\d+)\.html$/i
+    ];
+    for(const rx of patterns){
+      const m = pathname.match(rx);
+      if(m && m[1]) return 'L' + m[1];
+    }
+    return '';
+  }
+
+  function resolveIds(){
+    const root = document.getElementById('worksheetRoot');
+    let courseId = root?.dataset?.courseId || '';
+    let lessonId = root?.dataset?.lessonId || '';
+
+    if(!courseId && window.SIDEBAR?.selectedCourseId) courseId = window.SIDEBAR.selectedCourseId;
+    if(!lessonId && window.SIDEBAR?.selectedLessonId) lessonId = window.SIDEBAR.selectedLessonId;
+
+    const p = location.pathname;
+    const mf = window.LESSON_MANIFEST?.[p];
+    if(!courseId && mf?.course_id) courseId = mf.course_id;
+    if(!lessonId && mf?.lesson_id) lessonId = mf.lesson_id;
+
+    if(!courseId) courseId = guessCourseIdFromPath(p);
+    if(!lessonId) lessonId = guessLessonIdFromPath(p);
+
+    if(!courseId || !lessonId){
+      throw new Error(`Course/Lesson ID tidak ditemukan. \n    Path: ${p}\n    courseId: ${courseId || '-'} \n    lessonId: ${lessonId || '-'}\n    Pastikan salah satu tersedia: data-attribute di #worksheetRoot, sidebar.mod, manifest-lessons.js, atau penamaan file yang konsisten.`);
+    }
+    return {courseId, lessonId};
+  }
+
+  function showSuccessModal(storageUrl, driveUrl){
+    const modal = document.createElement('div');
+    Object.assign(modal.style,{
+      position:'fixed',top:'20%',left:'50%',transform:'translateX(-50%)',
+      background:'#fff',border:'1px solid #ccc',padding:'16px',zIndex:9999,
+      boxShadow:'0 2px 8px rgba(0,0,0,0.3)'
+    });
+    modal.innerHTML = `
+      <p>Worksheet tersimpan \u2705</p>
+      <p><a href="${storageUrl}" target="_blank" rel="noopener">View Storage</a></p>
+      <p><a href="${driveUrl}" target="_blank" rel="noopener">View Drive</a></p>
+      <button id="wsCloseModal">Tutup</button>
+    `;
+    document.body.appendChild(modal);
+    modal.querySelector('#wsCloseModal').addEventListener('click',()=>modal.remove());
+  }
+
+  window.initWorksheetSubmit = function initWorksheetSubmit(opts = {}){
+    const btn = document.querySelector('#btnSelesai, .btn-selesai');
+    if(!btn) return;
+
+    let courseId = opts.courseId;
+    let lessonId = opts.lessonId;
+
+    try{
+      if(!courseId || !lessonId){
+        const ids = resolveIds();
+        courseId = courseId || ids.courseId;
+        lessonId = lessonId || ids.lessonId;
+      }
+    }catch(e){
+      console.error(e);
+      btn.disabled = true;
+      btn.title = 'ID pelajaran tidak ditemukan. Hubungi admin untuk memperbaiki konfigurasi halaman.';
+      return;
+    }
+
+    fetchUser().then(user=>{
+      if(!user || !['guru','moderator'].includes(user.role)){
+        btn.disabled = true;
+        btn.title = 'Khusus Guru/Moderator';
+        return;
+      }
+      btn.addEventListener('click', async function(e){
+        e.preventDefault();
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = 'Menyimpan...';
+        try{
+          const answers = collectAnswers();
+          const screenshot = await capture('#worksheetRoot');
+          const payload = {
+            murid_uid: opts.muridUid,
+            cid: opts.cid || '',
+            nama_anak: opts.namaAnak || '',
+            course_id: courseId,
+            lesson_id: lessonId,
+            answers_text: answers,
+            screenshot_base64: screenshot
+          };
+          const res = await fetch('/api/worksheet/submit',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            credentials:'include',
+            body: JSON.stringify(payload)
+          });
+          const data = await res.json();
+          if(res.ok && data.ok){
+            showSuccessModal(data.storage_url, data.drive_url);
+          }else{
+            throw new Error(data.message || 'Gagal');
+          }
+        }catch(err){
+          alert('Gagal menyimpan worksheet: '+err.message);
+        }finally{
+          btn.disabled = false;
+          btn.textContent = original;
+        }
+      });
+    });
+  };
+})();

--- a/magicmirror-node/public/elearn/manifest-lessons.js
+++ b/magicmirror-node/public/elearn/manifest-lessons.js
@@ -1,0 +1,8 @@
+// Opsional: mapping path absolut -> { course_id, lesson_id }
+// Boleh dikosongkan; kalau ada entri, harus override deteksi otomatis.
+window.LESSON_MANIFEST = {
+  "/elearn/worlds/calistung/number/index.html": { course_id: "numbers-basic", lesson_id: "L1" },
+  // Contoh lainnya:
+  // "/elearn/worlds/calistung/number/A4a.html": { course_id: "numbers-basic", lesson_id: "L4" },
+  // "/elearn/worlds/calistung/number/B2.html": { course_id: "numbers-basic", lesson_id: "L7" },
+};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/index.html
@@ -26,7 +26,9 @@
     <div id="hudPanelContent"></div>
   </div>
 
-  <div id="worldRoot"></div>
+  <div id="worksheetRoot">
+    <div id="worldRoot"></div>
+  </div>
 
   <script type="module">
     import { initWorld } from '/elearn/worlds/map.js';
@@ -38,6 +40,16 @@
     initWorld({
       rootSelector: '#worldRoot',
       configPath: '/elearn/worlds/calistung/config.json'
+    });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  <script src="/elearn/manifest-lessons.js"></script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
+  <script>
+    initWorksheetSubmit({
+      muridUid: window.ACTIVE_MURID_UID,
+      cid: window.ACTIVE_MURID_CID || '',
+      namaAnak: window.ACTIVE_MURID_NAMA || ''
     });
   </script>
 </body>

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -211,6 +211,7 @@ async function getRewardHistory() {
 // Static assets and additional routers
 app.use('/generated_lessons', express.static(path.join(__dirname, '..', 'generated_lessons')));
 app.use(uploadModulRouter);
+app.use('/api/worksheet', require('./server/worksheet/submit'));
 
 app.get('/api/mirror-all', async (req, res) => {
   try {

--- a/magicmirror-node/server/worksheet/submit.js
+++ b/magicmirror-node/server/worksheet/submit.js
@@ -1,0 +1,144 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+const { google } = require('googleapis');
+const stream = require('stream');
+
+// simple in-memory rate limit: 10 requests per minute per IP
+const RATE_LIMIT = 10;
+const rateMap = new Map();
+function rateLimiter(req, res, next) {
+  const ip = req.ip || req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  const now = Date.now();
+  const windowMs = 60 * 1000;
+  const timestamps = rateMap.get(ip) || [];
+  const recent = timestamps.filter(t => now - t < windowMs);
+  recent.push(now);
+  rateMap.set(ip, recent);
+  if (recent.length > RATE_LIMIT) {
+    return res.status(429).json({ ok: false, code: 'rate_limit', message: 'Too many requests' });
+  }
+  next();
+}
+
+async function getGoogleClient() {
+  const base64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 || process.env.SERVICE_ACCOUNT_KEY_BASE64;
+  if (!base64) throw new Error('Missing service account key');
+  const credentials = JSON.parse(Buffer.from(base64, 'base64').toString('utf8'));
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: [
+      'https://www.googleapis.com/auth/drive.file',
+      'https://www.googleapis.com/auth/spreadsheets'
+    ]
+  });
+  return await auth.getClient();
+}
+
+router.post('/submit', rateLimiter, async (req, res) => {
+  try {
+    if (process.env.ENABLE_WORKSHEET_SUBMIT !== '1') {
+      return res.status(503).json({ ok: false, code: 'disabled', message: 'Worksheet submit disabled' });
+    }
+
+    const user = req.user || {};
+    if (!['guru', 'moderator'].includes(user.role)) {
+      return res.status(403).json({ ok: false, code: 'forbidden', message: 'Forbidden' });
+    }
+
+    const {
+      murid_uid,
+      cid = '',
+      nama_anak = '',
+      course_id,
+      lesson_id,
+      answers_text = '',
+      screenshot_base64
+    } = req.body || {};
+
+    if (!murid_uid || !course_id || !lesson_id || !screenshot_base64) {
+      return res.status(400).json({ ok: false, code: 'invalid', message: 'Missing required fields' });
+    }
+
+    const ts = Date.now();
+    const buffer = Buffer.from(screenshot_base64, 'base64');
+
+    // upload to Firebase Storage
+    const bucket = admin.storage().bucket();
+    const storagePath = `worksheets/${course_id}/${lesson_id}/${murid_uid}/${ts}.png`;
+    const file = bucket.file(storagePath);
+    await file.save(buffer, { contentType: 'image/png' });
+    const [storageUrl] = await file.getSignedUrl({ action: 'read', expires: '03-01-2500' });
+
+    // upload to Google Drive
+    const client = await getGoogleClient();
+    const drive = google.drive({ version: 'v3', auth: client });
+    const bufferStream = new stream.PassThrough();
+    bufferStream.end(buffer);
+    const driveResp = await drive.files.create({
+      requestBody: {
+        name: `${ts}_${course_id}_${lesson_id}_${murid_uid}.png`,
+        parents: [process.env.GDRIVE_WORKSHEET_FOLDER_ID].filter(Boolean),
+        mimeType: 'image/png'
+      },
+      media: { mimeType: 'image/png', body: bufferStream },
+      fields: 'id, webViewLink, webContentLink'
+    });
+    const driveFileId = driveResp.data.id;
+    try {
+      await drive.permissions.create({ fileId: driveFileId, requestBody: { role: 'reader', type: 'anyone' } });
+    } catch (e) {
+      console.error('drive permission error', e);
+    }
+    const driveUrl = driveResp.data.webViewLink || driveResp.data.webContentLink || '';
+
+    // append to Google Sheets
+    const sheets = google.sheets({ version: 'v4', auth: client });
+    const sheetRow = [
+      new Date(ts).toISOString(),
+      murid_uid,
+      cid,
+      nama_anak,
+      course_id,
+      lesson_id,
+      user.uid,
+      user.role,
+      answers_text.slice(0, 5000),
+      storageUrl,
+      driveUrl
+    ];
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: process.env.SPREADSHEET_ID,
+      range: 'EL_WORKSHEET',
+      valueInputOption: 'RAW',
+      requestBody: { values: [sheetRow] }
+    });
+
+    // save to Firestore
+    const db = admin.firestore();
+    const docId = `${murid_uid}_${course_id}_${lesson_id}_${ts}`;
+    await db.collection('worksheets').doc(docId).set({
+      ts,
+      murid_uid,
+      cid,
+      nama_anak,
+      course_id,
+      lesson_id,
+      submitted_by_uid: user.uid,
+      submitted_by_role: user.role,
+      answers_text: answers_text,
+      storage_url: storageUrl,
+      drive_file_id: driveFileId,
+      drive_url: driveUrl,
+      sheet_row_url_storage: storageUrl,
+      sheet_row_url_drive: driveUrl
+    });
+
+    res.json({ ok: true, storage_url: storageUrl, drive_url: driveUrl, sheet: { tab: 'EL_WORKSHEET' } });
+  } catch (err) {
+    console.error('worksheet submit error', err);
+    res.status(500).json({ ok: false, code: 'internal', message: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add worksheet submission endpoint with Storage, Drive, Sheets and Firestore integration
- mount new worksheet router
- capture worksheet answers and screenshot on frontend for guru/moderator roles
- auto-resolve course and lesson IDs with manifest, path parsing, or data attributes
- wire number world page to submit worksheet via new utility
- show success modal with links and send cookies with auth requests
- rely on manifest mapping for number world landing page so each level resolves its own IDs

## Testing
- `node --check magicmirror-node/public/elearn/manifest-lessons.js`
- `node --check magicmirror-node/public/elearn/common/worksheet-submit.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cefff0b2c8325b1a8ff0339a2b3cb