### PR TITLE
feat: add worksheet log viewer

### DIFF
--- a/magicmirror-node/public/elearn/sidebar-mod.html
+++ b/magicmirror-node/public/elearn/sidebar-mod.html
@@ -90,7 +90,11 @@
         <li><a href="/elearn/map.html"><i class="fas fa-school"></i> <span class="sidebar-label">School</span></a></li>
         <hr class="sidebar-divider">
       </div>
-          <div class="menu-group">
+      <div class="menu-group">
+        <li><a href="/elearn/worksheet-log.html">📄 Worksheet Log</a></li>
+        <hr class="sidebar-divider">
+      </div>
+      <div class="menu-group">
         <li><a href="/elearn/worlds/portal.html">🌍 Worlds</a></li>
         <hr class="sidebar-divider">
       </div>

--- a/magicmirror-node/public/elearn/worksheet-log.html
+++ b/magicmirror-node/public/elearn/worksheet-log.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Worksheet Log</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 16px; }
+    header { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+    .filters { display:flex; gap:8px; flex-wrap:wrap; margin: 10px 0 16px; }
+    input, select, button { padding:8px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border:1px solid #ddd; padding:8px; font-size:14px; vertical-align: top; }
+    th { background:#fafafa; position: sticky; top: 0; }
+    .muted { color:#777; font-size:12px; }
+    .pager { margin-top:10px; display:flex; gap:8px; align-items:center; }
+  </style>
+</head>
+<body>
+  <header>
+    <h2>Worksheet Log</h2>
+    <div class="muted" id="meta"></div>
+  </header>
+
+  <section class="filters">
+    <input id="q" placeholder="Cari (nama, UID, jawaban, drive link)" style="min-width:280px" />
+    <input id="cid" placeholder="CID" />
+    <input id="murid" placeholder="Nama/UID murid" />
+    <input id="course_id" placeholder="course_id (mis. numbers-basic)" />
+    <input id="lesson_id" placeholder="lesson_id (mis. L2)" />
+    <input id="date_from" type="date" />
+    <input id="date_to" type="date" />
+    <button id="btnApply">Terapkan</button>
+    <button id="btnReset">Reset</button>
+  </section>
+
+  <table id="tbl">
+    <thead>
+      <tr>
+        <th>Waktu (ts)</th>
+        <th>CID</th>
+        <th>Mur id / Nama</th>
+        <th>Course / Lesson</th>
+        <th>Links</th>
+        <th>Jawaban</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <div class="pager">
+    <button id="prev">Prev</button>
+    <span id="pageInfo" class="muted"></span>
+    <button id="next">Next</button>
+  </div>
+
+<script>
+const API_BASE = window.API_BASE || '';
+let limit = 50;
+let offset = 0;
+let lastTotal = 0;
+
+function val(id){ return document.getElementById(id).value.trim(); }
+
+function toQuery(params){
+  const p = new URLSearchParams();
+  Object.entries(params).forEach(([k,v]) => { if (v) p.set(k, v); });
+  return p.toString();
+}
+
+function fmtTs(v) {
+  if (!v) return '';
+  const d = new Date(v);
+  if (isNaN(d)) return v;
+  return d.toLocaleString();
+}
+
+function linkOrDash(url, label){
+  if (!url) return '—';
+  const safe = String(url).replace(/"/g,'&quot;');
+  return `<a href="${safe}" target="_blank" rel="noopener">${label}</a>`;
+}
+
+function render(items){
+  const tbody = document.querySelector('#tbl tbody');
+  tbody.innerHTML = items.map(r=>{
+    const links = [linkOrDash(r.drive_url,'Drive'), linkOrDash(r.storage_url,'Storage')].join(' · ');
+    const mur = [r.murid_uid || '', r.nama_anak || ''].filter(Boolean).join(' / ');
+    const cs = [r.course_id || '', r.lesson_id || ''].filter(Boolean).join(' / ');
+    const ans = (r.answers_text || '').slice(0, 300);
+    return `<tr>
+      <td>${fmtTs(r.ts)}</td>
+      <td>${r.cid || ''}</td>
+      <td>${mur}</td>
+      <td>${cs}</td>
+      <td>${links}</td>
+      <td><div style="max-width:520px; white-space:pre-wrap">${ans}</div></td>
+    </tr>`;
+  }).join('');
+}
+
+async function load(){
+  const params = {
+    q: val('q'),
+    cid: val('cid'),
+    murid: val('murid'),
+    course_id: val('course_id'),
+    lesson_id: val('lesson_id'),
+    date_from: val('date_from'),
+    date_to: val('date_to'),
+    limit, offset
+  };
+  const qs = toQuery(params);
+  const res = await fetch(`${API_BASE}/api/worksheet/log?` + qs, { credentials:'include' });
+  const data = await res.json();
+  if (!res.ok || !data.ok) throw new Error(data.error || 'Failed');
+
+  lastTotal = data.total || 0;
+  render(data.items || []);
+  document.getElementById('meta').textContent = `total: ${lastTotal}`;
+  const page = Math.floor(offset/limit)+1;
+  const pages = Math.max(1, Math.ceil(lastTotal/limit));
+  document.getElementById('pageInfo').textContent = `page ${page} / ${pages}`;
+}
+
+document.getElementById('btnApply').addEventListener('click', ()=>{ offset = 0; load(); });
+document.getElementById('btnReset').addEventListener('click', ()=>{
+  ['q','cid','murid','course_id','lesson_id','date_from','date_to'].forEach(id=>document.getElementById(id).value='');
+  offset = 0; load();
+});
+document.getElementById('prev').addEventListener('click', ()=>{
+  offset = Math.max(0, offset - limit); load();
+});
+document.getElementById('next').addEventListener('click', ()=>{
+  if (offset + limit < lastTotal) { offset += limit; load(); }
+});
+
+load().catch(e=> alert('Gagal load log: ' + e.message));
+</script>
+</body>
+</html>

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -318,6 +318,7 @@ async function getRewardHistory() {
 app.use('/generated_lessons', express.static(path.join(__dirname, '..', 'generated_lessons')));
 app.use(uploadModulRouter);
 app.use('/api/worksheet', require('./server/worksheet/submit'));
+app.use('/api/worksheet', require('./server/worksheet/log'));
 
 app.get('/api/mirror-all', async (req, res) => {
   try {

--- a/magicmirror-node/server/worksheet/log.js
+++ b/magicmirror-node/server/worksheet/log.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const router = express.Router();
+const { google } = require('googleapis');
+
+function getSheetsClient() {
+  const b64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 || process.env.SERVICE_ACCOUNT_KEY_BASE64;
+  if (!b64) throw new Error('Missing GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 for Sheets');
+  const credentials = JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+  const auth = new google.auth.JWT(
+    credentials.client_email,
+    null,
+    credentials.private_key,
+    ['https://www.googleapis.com/auth/spreadsheets.readonly']
+  );
+  return google.sheets({ version: 'v4', auth });
+}
+
+function parseDate(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d) ? null : d;
+}
+
+function like(haystack, needle) {
+  if (!needle) return true;
+  return String(haystack || '').toLowerCase().includes(String(needle).toLowerCase());
+}
+
+router.get('/log', async (req, res) => {
+  try {
+    const spreadsheetId = process.env.SPREADSHEET_ID;
+    if (!spreadsheetId) return res.status(500).json({ ok:false, error:'SPREADSHEET_ID env not set' });
+
+    const sheetName = process.env.GSHEET_TAB_WORKSHEET || 'EL_WORKSHEET';
+    const limit = Math.min(parseInt(req.query.limit || '100', 10), 1000);
+    const offset = Math.max(parseInt(req.query.offset || '0', 10), 0);
+
+    const sheets = getSheetsClient();
+    const range = `${sheetName}!A1:Z`;
+    const resp = await sheets.spreadsheets.values.get({ spreadsheetId, range });
+    const rows = resp.data.values || [];
+    if (rows.length < 2) return res.json({ ok:true, total:0, items:[] });
+
+    const headers = rows[0].map(h => String(h || '').trim());
+    const idx = Object.fromEntries(headers.map((h,i)=>[h,i]));
+    const asObj = (arr) => {
+      const o = {};
+      headers.forEach((h,i)=> o[h] = arr[i] ?? '');
+      return o;
+    };
+
+    // Ambil parameter filter
+    const { cid, murid, course_id, lesson_id, q } = req.query;
+    const dateFrom = parseDate(req.query.date_from);
+    const dateTo   = parseDate(req.query.date_to && req.query.date_to + 'T23:59:59');
+
+    // Mapping standar kolom (sesuaikan dengan header Sheet kamu)
+    // Disarankan header minimal: ts, cid, murid_uid, nama_anak, course_id, lesson_id, drive_url, storage_url, answers_text
+    const data = rows.slice(1).map(asObj).filter(r => {
+      // tanggal (ts) bisa berupa ISO/string
+      let passDate = true;
+      if (dateFrom || dateTo) {
+        const d = parseDate(r.ts);
+        passDate = !!d && (!dateFrom || d >= dateFrom) && (!dateTo || d <= dateTo);
+      }
+      return (
+        passDate &&
+        (!cid || String(r.cid || '').toLowerCase() === String(cid).toLowerCase()) &&
+        (!murid || like(r.nama_anak || r.murid_uid, murid)) &&
+        (!course_id || String(r.course_id || '').toLowerCase() === String(course_id).toLowerCase()) &&
+        (!lesson_id || String(r.lesson_id || '').toLowerCase() === String(lesson_id).toLowerCase()) &&
+        (!q || (like(r.nama_anak, q) || like(r.murid_uid, q) || like(r.answers_text, q) || like(r.drive_url, q)))
+      );
+    });
+
+    const total = data.length;
+    const items = data.slice(offset, offset + limit);
+    return res.json({ ok:true, total, limit, offset, items, headers });
+  } catch (e) {
+    console.error('[worksheet-log] error:', e);
+    return res.status(500).json({ ok:false, error: e.message || 'Internal error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `/api/worksheet/log` endpoint to list worksheet submissions
- create worksheet log dashboard with filters and pagination
- link worksheet log from moderator sidebar

## Testing
- `node -e "require('./server/worksheet/log'); console.log('log router ok');"`
- `npm test` *(fails: Missing script: "test")*
- `node server.js >/tmp/server.log 2>&1 & pid=$!; sleep 2; kill $pid; tail -n 20 /tmp/server.log`

------
https://chatgpt.com/codex/tasks/task_e_689f071f86748325bb58f9697171ba15