### PR TITLE
Integrate worksheet submit handler across calistung levels

### DIFF
--- a/magicmirror-node/public/elearn/calistung/level/A3.html
+++ b/magicmirror-node/public/elearn/calistung/level/A3.html
@@ -162,5 +162,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 3','/elearn/calistung/level/A4a.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A4a.html
+++ b/magicmirror-node/public/elearn/calistung/level/A4a.html
@@ -273,5 +273,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 4','/elearn/calistung/level/A5.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/A5.html
+++ b/magicmirror-node/public/elearn/calistung/level/A5.html
@@ -171,5 +171,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 5','/elearn/calistung/level/B1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B1.html
+++ b/magicmirror-node/public/elearn/calistung/level/B1.html
@@ -261,5 +261,26 @@ document.getElementById('checkButton').addEventListener('click', () => {
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 6','/elearn/calistung/level/B2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/B2.html
+++ b/magicmirror-node/public/elearn/calistung/level/B2.html
@@ -247,5 +247,26 @@ document.addEventListener('DOMContentLoaded', function () {
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 7','/elearn/calistung/level/C1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C1.html
+++ b/magicmirror-node/public/elearn/calistung/level/C1.html
@@ -164,5 +164,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 8','/elearn/calistung/level/C2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/C2.html
+++ b/magicmirror-node/public/elearn/calistung/level/C2.html
@@ -150,5 +150,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 9','/elearn/calistung/level/D1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D1.html
+++ b/magicmirror-node/public/elearn/calistung/level/D1.html
@@ -269,5 +269,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 10','/elearn/calistung/level/D2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/D2.html
+++ b/magicmirror-node/public/elearn/calistung/level/D2.html
@@ -556,5 +556,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 11','/elearn/calistung/level/E1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E1.html
+++ b/magicmirror-node/public/elearn/calistung/level/E1.html
@@ -361,5 +361,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 12','/elearn/calistung/level/E2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/E2.html
+++ b/magicmirror-node/public/elearn/calistung/level/E2.html
@@ -288,5 +288,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 13','/elearn/calistung/level/F1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/F1.html
+++ b/magicmirror-node/public/elearn/calistung/level/F1.html
@@ -220,5 +220,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 14','/elearn/calistung/level/G1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G1.html
+++ b/magicmirror-node/public/elearn/calistung/level/G1.html
@@ -212,5 +212,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 15','/elearn/calistung/level/G2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/G2.html
+++ b/magicmirror-node/public/elearn/calistung/level/G2.html
@@ -258,5 +258,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 16','/elearn/calistung/level/I1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I1.html
+++ b/magicmirror-node/public/elearn/calistung/level/I1.html
@@ -191,5 +191,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 17','/elearn/calistung/level/I2.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/I2.html
+++ b/magicmirror-node/public/elearn/calistung/level/I2.html
@@ -401,5 +401,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 18','/elearn/calistung/level/J1.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J1.html
+++ b/magicmirror-node/public/elearn/calistung/level/J1.html
@@ -226,5 +226,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 19','/elearn/calistung/level/J2a.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J2a.html
+++ b/magicmirror-node/public/elearn/calistung/level/J2a.html
@@ -293,5 +293,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 20','/elearn/calistung/level/J3.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>

--- a/magicmirror-node/public/elearn/calistung/level/J3.html
+++ b/magicmirror-node/public/elearn/calistung/level/J3.html
@@ -256,5 +256,26 @@
   import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
   addFinishButton('calistung','Level 21','/elearn/worlds/calistung/index.html');
 </script>
+
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  // Debug log
+  window.WORKSHEET_DEBUG = true;
+
+  // Ambil info user dari localStorage via userInfo.js
+  const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
+  const role = (info.role || '').toLowerCase();
+
+  initWorksheetSubmit({
+    muridUid: info.uid || '',
+    cid: info.cid || '',
+    namaAnak: info.nama || '',
+    role: role
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `worksheet-submit` helper on calistung levels A3 through J3
- standardize finish button submission via common init block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f29b0c2e8832589f046b181bac784