### PR TITLE
Fix sidebar and theme toggles across e-learning pages

### DIFF
--- a/magicmirror-node/public/elearn/manage-badges.html
+++ b/magicmirror-node/public/elearn/manage-badges.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Student Accounts – Admin</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <link rel="prefetch" href="/elearn/sidebar-mod.html" as="fetch" crossorigin>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -316,7 +317,7 @@
       .charts-row, .data-section, .cards-section { grid-template-columns: 1fr; }
     }
   </style>
-  <link rel="stylesheet" href="/elearn/css/sidebar-mod.css">
+  <link rel="stylesheet" href="/elearn/sidebar-mod.css">
 </head>
 <body>
   <div class="dashboard-layout">
@@ -326,7 +327,7 @@
       // Inject cached sidebar instantly to avoid flash
       (function() {
         try {
-          const cached = localStorage.getItem('sidebar_mod_html_v1');
+          const cached = localStorage.getItem('sidebar_mod_html_v2');
           const ph = document.getElementById('sidebar-placeholder');
           if (cached && ph) {
             ph.outerHTML = cached; // preserves original IDs/classes from cached HTML
@@ -335,7 +336,7 @@
       })();
     </script>
     <script type="module">
-      import { loadSidebar } from '/elearn/js/sidebar-init.js';
+      import { loadSidebar } from '/elearn/sidebar-init.js';
       loadSidebar();
     </script>
     <script src="/elearn/sidebar-meteor.js" defer></script>
@@ -345,7 +346,7 @@
         fetch('/elearn/sidebar-mod.html')
           .then(res => res.text())
           .then(html => {
-            try { localStorage.setItem('sidebar_mod_html_v1', html); } catch (e) {}
+            try { localStorage.setItem('sidebar_mod_html_v2', html); } catch (e) {}
             if (!document.getElementById('sidebar-container')) {
               const ph = document.getElementById('sidebar-placeholder');
               if (ph) ph.outerHTML = html;
@@ -355,6 +356,13 @@
       });
     </script>
     <main class="main-content" style="padding: 2rem;">
+      <section class="section-theme-toggle section-spacing" style="margin-bottom: 30px;">
+        <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
+          <button id="theme-toggle-btn" style="background: none; border: none; cursor: pointer; font-size: 1.3rem;">
+            <i id="theme-icon" class="fas fa-sun"></i>
+          </button>
+        </div>
+      </section>
       <h1 class="header-welcome" style="margin-bottom: 18px;">
         <i class="fas fa-award" style="color: #ff3c3c; margin-right: 10px;"></i> Manage Badges
       </h1>
@@ -704,8 +712,10 @@
     }
 
     function updateThemeIcon() {
+      const icon = document.getElementById('theme-icon');
+      if (!icon) return;
       const current = document.documentElement.getAttribute('data-theme') || 'light';
-      document.getElementById('theme-icon').textContent = current === 'dark' ? '🌙' : '☀️';
+      icon.className = current === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/magicmirror-node/public/elearn/moderator.html
+++ b/magicmirror-node/public/elearn/moderator.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard Moderator</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <link rel="prefetch" href="/elearn/sidebar-mod.html" as="fetch" crossorigin>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -351,7 +352,7 @@
       white-space: normal;
     }
   </style>
-  <link rel="stylesheet" href="/elearn/css/sidebar-mod.css">
+  <link rel="stylesheet" href="/elearn/sidebar-mod.css">
 </head>
 <body>
   <div class="dashboard-layout">
@@ -361,7 +362,7 @@
       // Inject cached sidebar instantly (anti flicker & ensure presence)
       (function() {
         try {
-          const cached = localStorage.getItem('sidebar_mod_html_v1');
+          const cached = localStorage.getItem('sidebar_mod_html_v2');
           const ph = document.getElementById('sidebar-placeholder');
           if (cached && ph && !document.getElementById('sidebar-container')) {
             ph.outerHTML = cached; // replace placeholder with full sidebar
@@ -370,7 +371,7 @@
       })();
     </script>
     <script type="module">
-      import { loadSidebar } from '/elearn/js/sidebar-init.js';
+      import { loadSidebar } from '/elearn/sidebar-init.js';
       loadSidebar();
     </script>
     <script src="/elearn/sidebar-meteor.js" defer></script>
@@ -380,7 +381,7 @@
         fetch('/elearn/sidebar-mod.html')
           .then(res => res.text())
           .then(html => {
-            try { localStorage.setItem('sidebar_mod_html_v1', html); } catch (e) {}
+            try { localStorage.setItem('sidebar_mod_html_v2', html); } catch (e) {}
             if (!document.getElementById('sidebar-container')) {
               const ph = document.getElementById('sidebar-placeholder');
               if (ph) ph.outerHTML = html;
@@ -394,7 +395,7 @@
       <section class="section-theme-toggle section-spacing" style="margin-bottom: 30px;">
         <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
           <button id="theme-toggle-btn" style="background: none; border: none; cursor: pointer; font-size: 1.3rem;">
-            <span id="theme-icon">☀️</span>
+            <i id="theme-icon" class="fas fa-sun"></i>
           </button>
         </div>
       </section>
@@ -772,8 +773,10 @@
     }
 
     function updateThemeIcon() {
+      const icon = document.getElementById('theme-icon');
+      if (!icon) return;
       const current = document.documentElement.getAttribute('data-theme') || 'light';
-      document.getElementById('theme-icon').textContent = current === 'dark' ? '🌙' : '☀️';
+      icon.className = current === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/magicmirror-node/public/elearn/notification.html
+++ b/magicmirror-node/public/elearn/notification.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Student Accounts – Admin</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'light');
@@ -315,14 +316,14 @@
       .charts-row, .data-section, .cards-section { grid-template-columns: 1fr; }
     }
   </style>
-  <link rel="stylesheet" href="/elearn/css/sidebar-mod.css">
+  <link rel="stylesheet" href="/elearn/sidebar-mod.css">
 </head>
 <body>
   <div class="dashboard-layout">
     <!-- Sidebar digantikan dengan file terpisah -->
     <div id="sidebar-placeholder"></div>
     <script type="module">
-      import { loadSidebar } from '/elearn/js/sidebar-init.js';
+      import { loadSidebar } from '/elearn/sidebar-init.js';
       loadSidebar().then(() => {
         if (typeof initSidebar === 'function') initSidebar();
         highlightActiveSidebarMenu(window.location.pathname);
@@ -330,6 +331,13 @@
     </script>
     <script src="/elearn/sidebar-meteor.js" defer></script>
     <main class="main-content" style="padding: 2rem;">
+      <section class="section-theme-toggle section-spacing" style="margin-bottom: 30px;">
+        <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
+          <button id="theme-toggle-btn" style="background: none; border: none; cursor: pointer; font-size: 1.3rem;">
+            <i id="theme-icon" class="fas fa-sun"></i>
+          </button>
+        </div>
+      </section>
       <h2 style="color: #e53935; font-weight: 700; font-size: 1.75rem; font-family: 'Inter', sans-serif; display: flex; align-items: center; gap: 10px;">
         <i class="fas fa-bell" style="color: #e53935;"></i>
         Notification Center
@@ -628,8 +636,10 @@
     }
 
     function updateThemeIcon() {
+      const icon = document.getElementById('theme-icon');
+      if (!icon) return;
       const current = document.documentElement.getAttribute('data-theme') || 'light';
-      document.getElementById('theme-icon').textContent = current === 'dark' ? '🌙' : '☀️';
+      icon.className = current === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/magicmirror-node/public/elearn/scoring.html
+++ b/magicmirror-node/public/elearn/scoring.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Student Accounts – Admin</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <link rel="prefetch" href="/elearn/sidebar-mod.html" as="fetch" crossorigin>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -316,7 +317,7 @@
       .charts-row, .data-section, .cards-section { grid-template-columns: 1fr; }
     }
   </style>
-  <link rel="stylesheet" href="/elearn/css/sidebar-mod.css">
+  <link rel="stylesheet" href="/elearn/sidebar-mod.css">
 </head>
 <body>
   <div class="dashboard-layout">
@@ -326,7 +327,7 @@
       // Inject cached sidebar instantly to avoid flash
       (function() {
         try {
-          const cached = localStorage.getItem('sidebar_mod_html_v1');
+          const cached = localStorage.getItem('sidebar_mod_html_v2');
           const ph = document.getElementById('sidebar-placeholder');
           if (cached && ph) {
             ph.outerHTML = cached; // preserves original IDs/classes from cached HTML
@@ -335,7 +336,7 @@
       })();
     </script>
     <script type="module">
-      import { loadSidebar } from '/elearn/js/sidebar-init.js';
+      import { loadSidebar } from '/elearn/sidebar-init.js';
       loadSidebar();
     </script>
     <script src="/elearn/sidebar-meteor.js" defer></script>
@@ -345,7 +346,7 @@
         fetch('/elearn/sidebar-mod.html')
           .then(res => res.text())
           .then(html => {
-            try { localStorage.setItem('sidebar_mod_html_v1', html); } catch (e) {}
+            try { localStorage.setItem('sidebar_mod_html_v2', html); } catch (e) {}
             if (!document.getElementById('sidebar-container')) {
               const ph = document.getElementById('sidebar-placeholder');
               if (ph) ph.outerHTML = html;
@@ -355,6 +356,13 @@
       });
     </script>
     <main class="main-content">
+      <section class="section-theme-toggle section-spacing" style="margin-bottom: 30px;">
+        <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
+          <button id="theme-toggle-btn" style="background: none; border: none; cursor: pointer; font-size: 1.3rem;">
+            <i id="theme-icon" class="fas fa-sun"></i>
+          </button>
+        </div>
+      </section>
       <div class="container px-4 py-6">
         <h1 class="text-xl font-bold text-red-500 flex items-center">
           <i class="fas fa-clipboard-check mr-2"></i> Auto/Manual Scoring
@@ -670,8 +678,10 @@
     }
 
     function updateThemeIcon() {
+      const icon = document.getElementById('theme-icon');
+      if (!icon) return;
       const current = document.documentElement.getAttribute('data-theme') || 'light';
-      document.getElementById('theme-icon').textContent = current === 'dark' ? '🌙' : '☀️';
+      icon.className = current === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/magicmirror-node/public/elearn/sidebar-init.js
+++ b/magicmirror-node/public/elearn/sidebar-init.js
@@ -6,7 +6,7 @@ export async function loadSidebar() {
 
   // 1) Inject cached HTML instantly (anti flicker)
   try {
-    const cached = localStorage.getItem('sidebar_mod_html_v1');
+    const cached = localStorage.getItem('sidebar_mod_html_v2');
     if (cached && ph && !document.getElementById('sidebar-container')) {
       ph.outerHTML = cached; // langsung ganti placeholder dengan sidebar utuh
       safeInitSidebar();     // init cepat dari cache
@@ -17,7 +17,7 @@ export async function loadSidebar() {
   try {
     const res = await fetch('/elearn/sidebar-mod.html', { cache: 'no-store' });
     const html = await res.text();
-    try { localStorage.setItem('sidebar_mod_html_v1', html); } catch (_) {}
+    try { localStorage.setItem('sidebar_mod_html_v2', html); } catch (_) {}
 
     const hasSidebar = !!document.getElementById('sidebar-container');
     const hasToggle  = !!document.getElementById('sidebar-toggle');

--- a/magicmirror-node/public/elearn/sidebar-mod.css
+++ b/magicmirror-node/public/elearn/sidebar-mod.css
@@ -297,6 +297,7 @@ body, html {
     background: linear-gradient(90deg, white, transparent);
     position: absolute;
     z-index: 999;
+    pointer-events: none;
     offset-path: path("M20,20 H220 A20,20 0 0 1 240,40 V620 A20,20 0 0 1 220,640 H20 A20,20 0 0 1 0,620 V40 A20,20 0 0 1 20,20 Z");
     offset-rotate: auto;
     offset-distance: 0%;

--- a/magicmirror-node/public/elearn/sidebar-mod.html
+++ b/magicmirror-node/public/elearn/sidebar-mod.html
@@ -5,6 +5,7 @@
     background: linear-gradient(90deg, white, transparent);
     position: absolute;
     z-index: 999;
+    pointer-events: none;
     offset-distance: 0%;
     offset-rotate: auto;
     animation: moveMeteor 4s linear infinite;

--- a/magicmirror-node/public/elearn/student-acc.html
+++ b/magicmirror-node/public/elearn/student-acc.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Student Accounts – Admin</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <link rel="prefetch" href="/elearn/sidebar-mod.html" as="fetch" crossorigin>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -316,7 +317,7 @@
       .charts-row, .data-section, .cards-section { grid-template-columns: 1fr; }
     }
   </style>
-  <link rel="stylesheet" href="/elearn/css/sidebar-mod.css">
+  <link rel="stylesheet" href="/elearn/sidebar-mod.css">
 </head>
 <body>
   <div class="dashboard-layout">
@@ -326,7 +327,7 @@
       // Inject cached sidebar instantly (avoid flash, ensure presence)
       (function() {
         try {
-          const cached = localStorage.getItem('sidebar_mod_html_v1');
+          const cached = localStorage.getItem('sidebar_mod_html_v2');
           const ph = document.getElementById('sidebar-placeholder');
           if (cached && ph && !document.getElementById('sidebar-container')) {
             ph.outerHTML = cached; // replace placeholder with full sidebar from cache
@@ -335,7 +336,7 @@
       })();
     </script>
     <script type="module">
-      import { loadSidebar } from '/elearn/js/sidebar-init.js';
+      import { loadSidebar } from '/elearn/sidebar-init.js';
       loadSidebar();
     </script>
     <script src="/elearn/sidebar-meteor.js" defer></script>
@@ -406,7 +407,7 @@
         fetch('/elearn/sidebar-mod.html')
           .then(res => res.text())
           .then(html => {
-            try { localStorage.setItem('sidebar_mod_html_v1', html); } catch (e) {}
+            try { localStorage.setItem('sidebar_mod_html_v2', html); } catch (e) {}
             if (!document.getElementById('sidebar-container')) {
               const ph = document.getElementById('sidebar-placeholder');
               if (ph) ph.outerHTML = html;
@@ -420,7 +421,7 @@
       <section class="section-theme-toggle section-spacing" style="margin-bottom: 30px;">
         <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
           <button id="theme-toggle-btn" style="background: none; border: none; cursor: pointer; font-size: 1.3rem;">
-            <span id="theme-icon">☀️</span>
+            <i id="theme-icon" class="fas fa-sun"></i>
           </button>
         </div>
       </section>
@@ -787,8 +788,10 @@
     }
 
     function updateThemeIcon() {
+      const icon = document.getElementById('theme-icon');
+      if (!icon) return;
       const current = document.documentElement.getAttribute('data-theme') || 'light';
-      document.getElementById('theme-icon').textContent = current === 'dark' ? '🌙' : '☀️';
+      icon.className = current === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
     }
 
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- force refresh of sidebar HTML so collapse/expand button appears on all pages
- add Font Awesome sun/moon theme toggles to moderator, manage-badges, notification, scoring, and student account pages
- prevent decorative meteor overlay from blocking sidebar clicks

## Testing
- `npm test` *(fails: Missing script: "test" as npm throws Missing script error)*

------
https://chatgpt.com/codex/tasks/task_e_68a162d2e6ec8325b3ea3f878db8de85