### PR TITLE
Add finish button component for math game levels

### DIFF
--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L1.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L1.html
@@ -169,17 +169,31 @@
     generateLegend();
     generateQuestions();
   </script>
-  <div style="text-align: center; margin-top: 20px;">
-    <button id="finishBtn-L1" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-  </div>
-  <script>
-    function submitLevelL1() {
-      alert("Level selesai!");
-      fetch("/elearn/worlds/calistung/math-game/config.json")
-        .then(() => console.log("progress saved"));
-      window.location.href = "/elearn/worlds/calistung/math-game/index.html";
-    }
-    document.getElementById("finishBtn-L1").addEventListener("click", submitLevelL1);
-  </script>
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L10.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L10.html
@@ -178,17 +178,31 @@
     document.getElementById('resetBtn').addEventListener('click', resetAll);
     document.getElementById('checkBtn').addEventListener('click', check);
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L10" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL10() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L10").addEventListener("click", submitLevelL10);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L11.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L11.html
@@ -288,17 +288,31 @@
     // init
     generate(8);
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L11" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL11() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L11").addEventListener("click", submitLevelL11);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L12.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L12.html
@@ -376,17 +376,31 @@
   restartGame();
 })();
 </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L12" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL12() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L12").addEventListener("click", submitLevelL12);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L13.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L13.html
@@ -511,17 +511,31 @@
     ro.observe(canvas);
     resizeCanvasForHiDPI();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L13" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL13() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L13").addEventListener("click", submitLevelL13);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L14.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L14.html
@@ -251,17 +251,31 @@
     generateRound(true);
   })();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L14" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL14() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L14").addEventListener("click", submitLevelL14);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L2.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L2.html
@@ -271,17 +271,31 @@ function celebrate(){
 
 build();
 </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L2" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL2() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L2").addEventListener("click", submitLevelL2);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L3.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L3.html
@@ -198,17 +198,31 @@
       status.textContent = 'Soal diacak! Pilih warna lagi dan lanjutkan.';
     });
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L3" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL3() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L3").addEventListener("click", submitLevelL3);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L4.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L4.html
@@ -186,17 +186,31 @@
       alert(`Jawaban benar: ${benar} dari ${soalBoxes.length}`);
     }
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L4" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL4() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L4").addEventListener("click", submitLevelL4);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L5.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L5.html
@@ -171,17 +171,31 @@
     document.getElementById('shuffle').addEventListener('click', bootstrap);
     bootstrap();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L5" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL5() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L5").addEventListener("click", submitLevelL5);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L6.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L6.html
@@ -150,17 +150,31 @@
 
     setupQuestions();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L6" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL6() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L6").addEventListener("click", submitLevelL6);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L7.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L7.html
@@ -246,17 +246,31 @@
     assignProblems();
     selectColor(null); // belum pilih
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L7" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL7() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L7").addEventListener("click", submitLevelL7);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L8a.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L8a.html
@@ -316,17 +316,31 @@
     $('#btnShuffle').addEventListener('click', shuffleAll);
     genProblems(); render();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L8a" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL8a() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L8a").addEventListener("click", submitLevelL8a);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L9.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L9.html
@@ -143,17 +143,31 @@
     generateLegend();
     generateQuestions();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L9" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL9() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L9").addEventListener("click", submitLevelL9);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace placeholder finish buttons with reusable worksheet submit component on all math game level pages
- Integrate html2canvas and worksheet submit scripts for screenshot, progress lock and points award

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a49971e2948325b4f4ed1791490520