### PR TITLE
Add finish button component for math and number levels

### DIFF
--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L1.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L1.html
@@ -169,17 +169,32 @@
     generateLegend();
     generateQuestions();
   </script>
-  <div style="text-align: center; margin-top: 20px;">
-    <button id="finishBtn-L1" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-  </div>
-  <script>
-    function submitLevelL1() {
-      alert("Level selesai!");
-      fetch("/elearn/worlds/calistung/math-game/config.json")
-        .then(() => console.log("progress saved"));
-      window.location.href = "/elearn/worlds/calistung/math-game/index.html";
-    }
-    document.getElementById("finishBtn-L1").addEventListener("click", submitLevelL1);
-  </script>
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
+</script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L10.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L10.html
@@ -178,17 +178,32 @@
     document.getElementById('resetBtn').addEventListener('click', resetAll);
     document.getElementById('checkBtn').addEventListener('click', check);
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L10" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL10() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L10").addEventListener("click", submitLevelL10);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L11.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L11.html
@@ -288,17 +288,32 @@
     // init
     generate(8);
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L11" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL11() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L11").addEventListener("click", submitLevelL11);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L12.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L12.html
@@ -376,17 +376,32 @@
   restartGame();
 })();
 </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L12" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL12() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L12").addEventListener("click", submitLevelL12);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L13.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L13.html
@@ -511,17 +511,32 @@
     ro.observe(canvas);
     resizeCanvasForHiDPI();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L13" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL13() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L13").addEventListener("click", submitLevelL13);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L14.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L14.html
@@ -251,17 +251,32 @@
     generateRound(true);
   })();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L14" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL14() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L14").addEventListener("click", submitLevelL14);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L2.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L2.html
@@ -271,17 +271,32 @@ function celebrate(){
 
 build();
 </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L2" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL2() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L2").addEventListener("click", submitLevelL2);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L3.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L3.html
@@ -198,17 +198,32 @@
       status.textContent = 'Soal diacak! Pilih warna lagi dan lanjutkan.';
     });
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L3" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL3() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L3").addEventListener("click", submitLevelL3);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L4.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L4.html
@@ -186,17 +186,32 @@
       alert(`Jawaban benar: ${benar} dari ${soalBoxes.length}`);
     }
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L4" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL4() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L4").addEventListener("click", submitLevelL4);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L5.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L5.html
@@ -171,17 +171,32 @@
     document.getElementById('shuffle').addEventListener('click', bootstrap);
     bootstrap();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L5" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL5() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L5").addEventListener("click", submitLevelL5);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L6.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L6.html
@@ -150,17 +150,32 @@
 
     setupQuestions();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L6" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL6() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L6").addEventListener("click", submitLevelL6);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L7.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L7.html
@@ -246,17 +246,32 @@
     assignProblems();
     selectColor(null); // belum pilih
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L7" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL7() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L7").addEventListener("click", submitLevelL7);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L8a.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L8a.html
@@ -316,17 +316,32 @@
     $('#btnShuffle').addEventListener('click', shuffleAll);
     genProblems(); render();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L8a" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL8a() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L8a").addEventListener("click", submitLevelL8a);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L9.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/mg-L9.html
@@ -143,17 +143,32 @@
     generateLegend();
     generateQuestions();
   </script>
-<div style="text-align: center; margin-top: 20px;">
-  <button id="finishBtn-L9" style="padding: 10px 20px; background-color: green; color: white; border: none; border-radius: 5px; cursor: pointer;">Selesai</button>
-</div>
-<script>
-  function submitLevelL9() {
-    alert("Level selesai!");
-    fetch("/elearn/worlds/calistung/math-game/config.json")
-      .then(() => console.log("progress saved"));
-    window.location.href = "/elearn/worlds/calistung/math-game/index.html";
+
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
   }
-  document.getElementById("finishBtn-L9").addEventListener("click", submitLevelL9);
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script src="/elearn/manifest-lessons.js"></script>
+<script src="/elearn/userInfo.js"></script>
+<script src="/elearn/common/worksheet-submit.js"></script>
+<script>
+  window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "mathgame-basic" };
+  const info = (typeof getUserInfo === "function") ? getUserInfo() : {};
+  initWorksheetSubmit({
+    muridUid: info.uid || "",
+    cid: info.cid || "",
+    namaAnak: info.nama || "",
+    role: (info.role || "").toLowerCase()
+  });
 </script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L1.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L1.html
@@ -140,18 +140,7 @@
             }
         }
         .worksheet-slide { width: 100%; }
-        /* Finish button (Level 1) */
-        .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
-        #btnSelesai {
-            background: #22c55e; color: #fff; border: none; cursor: pointer;
-            padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px;
-            box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4);
-        }
-        #btnSelesai:hover { filter: brightness(1.05); }
-        #btnSelesai:active { transform: translateY(1px); }
-        @media (max-width: 480px) {
-            #btnSelesai { padding: 10px 14px; font-size: 15px; }
-        }
+}
         /* Tool bar for brush/eraser */
         .tool-bar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
         .tool-btn { padding:8px 10px; border:1px solid #ccc; background:#fff; border-radius:8px; cursor:pointer; font-weight:600; }
@@ -997,10 +986,17 @@
     </script>
 </div>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 1','/elearn/calistung/level/A2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
 <script src="/elearn/userInfo.js"></script>
@@ -1008,6 +1004,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L10.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L10.html
@@ -152,7 +152,6 @@
     }
   }
 </style>
-<link rel="stylesheet" href="button.css">
 </head>
 <body>
   <main class="container" role="main" aria-label="Belajar Coding Matematika interactive game">
@@ -265,10 +264,17 @@
   })();
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 10','/elearn/calistung/level/D2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -277,6 +283,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L11.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L11.html
@@ -552,10 +552,17 @@
 
 <button id="check-btn" class="clay-button">Periksa Jawaban</button>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 11','/elearn/calistung/level/E1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -564,6 +571,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L12.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L12.html
@@ -3,8 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Color By Number - Game E1</title>
-  <link rel="stylesheet" href="button.css">
-  <style>
+<style>
     body {
       font-family: Arial, sans-serif;
       text-align: center;
@@ -357,10 +356,17 @@
     }
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 12','/elearn/calistung/level/E2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -369,6 +375,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L13.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L13.html
@@ -284,10 +284,17 @@
     init();
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 13','/elearn/calistung/level/F1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -296,6 +303,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L14.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L14.html
@@ -216,10 +216,17 @@
   function toast(msg){ document.getElementById('toast').textContent = msg; }
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 14','/elearn/calistung/level/G1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -228,6 +235,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L15.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L15.html
@@ -208,10 +208,17 @@
     setTimeout(normalizeExpected, 0);
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 15','/elearn/calistung/level/G2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -220,6 +227,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L16.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L16.html
@@ -254,10 +254,17 @@
 })();
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 16','/elearn/calistung/level/I1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -266,6 +273,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L17.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L17.html
@@ -187,10 +187,17 @@
     }
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 17','/elearn/calistung/level/I2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -199,6 +206,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L18.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L18.html
@@ -397,10 +397,17 @@
     window.addEventListener('resize', ()=>{ layoutArc(); computePositions(); drawPuzzleLines(); });
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 18','/elearn/calistung/level/J1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -409,6 +416,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L19.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L19.html
@@ -222,10 +222,17 @@
 })();
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 19','/elearn/calistung/level/J2a.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -234,6 +241,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L2.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L2.html
@@ -107,9 +107,7 @@
       transform: translateY(2px);
     }
   </style>
-  <link rel="stylesheet" href="button.css">
-
-  <div class="mobil-container" id="mobilContainer">
+<div class="mobil-container" id="mobilContainer">
     <!-- Mobil akan dirender di sini -->
   </div>
 
@@ -298,17 +296,24 @@ document.querySelectorAll(".color-code div").forEach((el) => {
   <button id="checkButton" class="clay-button">Periksa Jawaban</button>
   <div id="result" style="margin-top: 15px; font-weight: bold;"></div>
 
-  <script type="module">
-    import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-    // game=calistung, label=Level 2, next URL to A3
-    addFinishButton('calistung', 'Level 2', '/elearn/calistung/level/A3.html');
-  </script>
+  <style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script src="/elearn/manifest-lessons.js"></script>
   <script src="/elearn/userInfo.js"></script>
   <script src="/elearn/common/worksheet-submit.js"></script>
   <script>
     window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
     const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};
     const role = (info.role || '').toLowerCase();
     initWorksheetSubmit({

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L20.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L20.html
@@ -289,10 +289,17 @@
 })();
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 20','/elearn/calistung/level/J3.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -301,6 +308,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L21.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L21.html
@@ -252,10 +252,17 @@
     render();
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 21','/elearn/worlds/calistung/index.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -264,6 +271,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L3.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L3.html
@@ -75,7 +75,6 @@
       transition: background-color 0.3s;
     }
 </style>
-<link rel="stylesheet" href="button.css">
 </head>
 <body>
   <h2>Mengenal dan Mewarnai Angka</h2>
@@ -158,26 +157,26 @@
     });
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 3','/elearn/calistung/level/A4a.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
-<script>
-  // Guard: pastikan manifest untuk halaman ini ada dan benar
-  (function(){
-    var path = "/elearn/calistung/level/A3.html";
-    window.LESSON_MANIFEST = window.LESSON_MANIFEST || {};
-    window.LESSON_MANIFEST[path] = { course_id: "numbers-basic", lesson_id: "L3" };
-  })();
-</script>
 <script src="/elearn/userInfo.js"></script>
 <script src="/elearn/common/worksheet-submit.js"></script>
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L4.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L4.html
@@ -117,7 +117,6 @@
       width: 100%;
     }
   </style>
-  <link rel="stylesheet" href="button.css">
 </head>
 <body>
   <div class="container">
@@ -269,10 +268,17 @@
     }
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 4','/elearn/calistung/level/A5.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -281,6 +287,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L5.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L5.html
@@ -72,7 +72,6 @@
     }
     
   </style>
-  <link rel="stylesheet" href="button.css">
 </head>
 <body>
   <h2 class="instruction" style="color: #FF69B4; font-size: 28px;">Lingkari Sesuai Petunjuk Warna</h2>
@@ -167,10 +166,17 @@
     });
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 5','/elearn/calistung/level/B1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -179,6 +185,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L6.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L6.html
@@ -89,7 +89,6 @@
     }
   }
 </style>
-<link rel="stylesheet" href="button.css">
 </style>
 </head>
 <body>
@@ -257,10 +256,17 @@ document.getElementById('checkButton').addEventListener('click', () => {
 });
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 6','/elearn/calistung/level/B2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -269,6 +275,7 @@ document.getElementById('checkButton').addEventListener('click', () => {
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L7.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L7.html
@@ -137,7 +137,6 @@
       border-radius: 50%;
     }
 </style>
-<link rel="stylesheet" href="button.css">
 </head>
 <body>
   <h2>Silakan Diwarnai Sesuai Petunjuk</h2>
@@ -243,10 +242,17 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 7','/elearn/calistung/level/C1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -255,6 +261,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L8.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L8.html
@@ -160,10 +160,17 @@
   `;
 </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 8','/elearn/calistung/level/C2.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -172,6 +179,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};

--- a/magicmirror-node/public/elearn/worlds/calistung/number/number-L9.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/number/number-L9.html
@@ -61,7 +61,6 @@
       font-weight: bold;
     }
   </style>
-  <link rel="stylesheet" href="button.css">
 </head>
 <body>
   <div class="instruction">Coding Exercise</div>
@@ -146,10 +145,17 @@
     });
   </script>
 
-<script type="module">
-  import { addFinishButton } from '/elearn/worlds/utils/finish-button.js';
-  addFinishButton('calistung','Level 9','/elearn/calistung/level/D1.html');
-</script>
+<style>
+  .finish-bar { position: fixed; right: 16px; bottom: 16px; z-index: 1000; }
+  #btnSelesai { background: #22c55e; color: #fff; border: none; cursor: pointer; padding: 12px 16px; border-radius: 12px; font-weight: 700; font-size: 16px; box-shadow: 0 6px 18px rgba(16, 185, 129, 0.4); }
+  #btnSelesai:hover { filter: brightness(1.05); }
+  #btnSelesai:active { transform: translateY(1px); }
+  @media (max-width: 480px) {
+    #btnSelesai { padding: 10px 14px; font-size: 15px; }
+  }
+</style>
+
+<div class="finish-bar"><button id="btnSelesai" type="button">Selesai</button></div>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="/elearn/manifest-lessons.js"></script>
@@ -158,6 +164,7 @@
 <script>
   // Debug log
   window.WORKSHEET_DEBUG = true;
+  window.WORKSHEET_META = { course_id: "numbers-basic" };
 
   // Ambil info user dari localStorage via userInfo.js
   const info = (typeof getUserInfo === 'function') ? getUserInfo() : {};


### PR DESCRIPTION
## Summary
- Replace placeholder finish buttons with reusable worksheet submit component on all math game level pages
- Integrate html2canvas and worksheet submit scripts for screenshot, progress lock and points award
- Add the same finish button component and course metadata to all number world levels

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a49971e2948325b4f4ed1791490520