### PR TITLE
Add client-side CID fallback and fix moderator redirect

### DIFF
--- a/magicmirror-node/public/elearn/daftar.html
+++ b/magicmirror-node/public/elearn/daftar.html
@@ -458,7 +458,9 @@
           if (!r.ok) continue; const j = await r.json(); if (j && j.cid) return j.cid;
         }catch(_){ /* try next */ }
       }
-      throw new Error('Failed to generate CID');
+      // Fallback: generate a pseudo CID on the client if backend is unreachable
+      const randomNumber = Math.floor(10000000 + Math.random() * 90000000);
+      return 'CQA' + randomNumber;
     }
 
     async function registerBackend(payload){

--- a/magicmirror-node/public/elearn/login-elearningu.html
+++ b/magicmirror-node/public/elearn/login-elearningu.html
@@ -242,11 +242,11 @@ async function login() {
         localStorage.setItem("nama", data.nama);
         localStorage.setItem("role", data.role);
 
-        if (data.role === "moderator") {
-          window.location.href = "/elearn/moderator.html";
-        } else {
-          window.location.href = "/elearn/murid.html";
-        }
+          if (data.role === "moderator") {
+            window.location.href = "/mod/moderator.html";
+          } else {
+            window.location.href = "/elearn/murid.html";
+          }
       } catch (err) {
         console.error(err);
         errorEl.innerText = "❌ Login gagal. Periksa email dan password kamu.";

--- a/magicmirror-node/public/elearn/script.js
+++ b/magicmirror-node/public/elearn/script.js
@@ -50,7 +50,7 @@ async function login() {
     } else if (data.role === "ortu") {
       window.location.href = "/elearn/ortu.html";
     } else if (data.role === "moderator") {
-      window.location.href = "/elearn/moderator.html";
+      window.location.href = "/mod/moderator.html";
     } else {
       errorEl.innerText = "❌ Role tidak dikenali.";
     }

--- a/magicmirror-node/public/elearn/sidebar.html
+++ b/magicmirror-node/public/elearn/sidebar.html
@@ -23,10 +23,10 @@
       <span class="material-icons icon icon-emboss">person</span>
       <span>Profile</span>
     </a>
-    <a href="/elearn/moderator.html" id="moderator-link" style="display:none;">
-      <span class="material-icons icon icon-emboss">admin_panel_settings</span>
-      <span>Moderator</span>
-    </a>
+      <a href="/mod/moderator.html" id="moderator-link" style="display:none;">
+        <span class="material-icons icon icon-emboss">admin_panel_settings</span>
+        <span>Moderator</span>
+      </a>
 
     <!--
     <a href="/elearn/modul1_lesson1.html">


### PR DESCRIPTION
## Summary
- allow daftar.html to generate a fallback CID when backend is unreachable
- send moderator users to /mod/moderator.html across login flows and sidebar

## Testing
- `npm test` (fails: Missing script: "test")
- `npm test` in firebase-upload-backend (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ab8ce14cb08325a9b43de1f50746d1