### PR TITLE
Fix Queens Academy start video paths

### DIFF
--- a/magicmirror-node/public/queensacademy.id/start.html
+++ b/magicmirror-node/public/queensacademy.id/start.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Queen's Academy &bull; Start Game</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Rajdhani:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --primary: #ff3ff5;
+        --primary-dark: #7a13ff;
+        --secondary: #18f1ff;
+        --text-light: #f4f7ff;
+        --panel-bg: rgba(8, 8, 24, 0.75);
+        --panel-border: rgba(255, 255, 255, 0.2);
+        --glow: 0 0 25px rgba(255, 64, 246, 0.55);
+        color-scheme: dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Rajdhani", "Segoe UI", sans-serif;
+        color: var(--text-light);
+        background: #050515;
+        overflow: hidden;
+      }
+
+      video.bg-video {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        min-width: 100%;
+        min-height: 100%;
+        width: auto;
+        height: auto;
+        transform: translate(-50%, -50%);
+        object-fit: cover;
+        filter: saturate(1.2) contrast(1.05) brightness(0.95);
+        z-index: -2;
+      }
+
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: linear-gradient(
+            120deg,
+            rgba(6, 6, 30, 0.85) 0%,
+            rgba(20, 9, 40, 0.55) 45%,
+            rgba(2, 11, 28, 0.75) 100%
+          ),
+          radial-gradient(circle at 20% 20%, rgba(52, 8, 135, 0.35), transparent 55%),
+          radial-gradient(circle at 80% 70%, rgba(14, 112, 158, 0.35), transparent 50%);
+        z-index: -1;
+      }
+
+      .content {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2.5rem;
+        min-height: 100vh;
+        padding: 3rem 1.5rem;
+        text-align: center;
+      }
+
+      .branding {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        align-items: center;
+        max-width: 620px;
+      }
+
+      .branding h1 {
+        margin: 0;
+        font-family: "Orbitron", sans-serif;
+        font-size: clamp(2.75rem, 6vw, 4.5rem);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        text-shadow: 0 0 25px rgba(0, 0, 0, 0.75), 0 0 40px rgba(24, 241, 255, 0.6);
+      }
+
+      .branding p {
+        margin: 0;
+        font-size: clamp(1.05rem, 2.5vw, 1.45rem);
+        line-height: 1.5;
+        letter-spacing: 0.05em;
+        opacity: 0.9;
+      }
+
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        width: min(420px, 100%);
+      }
+
+      @media (min-width: 640px) {
+        .actions {
+          flex-direction: row;
+          justify-content: center;
+        }
+      }
+
+      .cta-button {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.65rem;
+        padding: 0.9rem 2.7rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background: linear-gradient(120deg, var(--primary), var(--primary-dark));
+        color: var(--text-light);
+        font-family: "Orbitron", sans-serif;
+        font-size: 1.05rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        text-decoration: none;
+        box-shadow: var(--glow);
+        transition: transform 180ms ease, box-shadow 180ms ease, filter 180ms ease;
+      }
+
+      .cta-button svg {
+        width: 1.1rem;
+        height: 1.1rem;
+        fill: currentColor;
+      }
+
+      .cta-button:hover,
+      .cta-button:focus-visible {
+        transform: translateY(-2px) scale(1.02);
+        box-shadow: 0 0 35px rgba(255, 64, 246, 0.75);
+        filter: saturate(1.1);
+        outline: none;
+      }
+
+      .cta-button.secondary {
+        background: linear-gradient(120deg, rgba(24, 241, 255, 0.9), rgba(76, 106, 255, 0.9));
+        box-shadow: 0 0 22px rgba(24, 241, 255, 0.5);
+      }
+
+      .settings-wrapper {
+        position: absolute;
+        top: 1.5rem;
+        right: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.75rem;
+      }
+
+      .settings-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1.25rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(10, 10, 40, 0.65);
+        color: var(--text-light);
+        font-family: "Orbitron", sans-serif;
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+      }
+
+      .settings-toggle svg {
+        width: 1rem;
+        height: 1rem;
+        fill: currentColor;
+      }
+
+      .settings-toggle:hover,
+      .settings-toggle:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 0 16px rgba(24, 241, 255, 0.55);
+        outline: none;
+      }
+
+      .settings-menu {
+        position: relative;
+        padding: 1.25rem;
+        width: min(240px, 90vw);
+        border-radius: 18px;
+        background: var(--panel-bg);
+        border: 1px solid var(--panel-border);
+        backdrop-filter: blur(12px);
+        display: none;
+        flex-direction: column;
+        gap: 1rem;
+        box-shadow: 0 18px 45px rgba(3, 6, 28, 0.45);
+      }
+
+      .settings-menu.active {
+        display: flex;
+        animation: fadeIn 220ms ease;
+      }
+
+      .settings-menu h2 {
+        margin: 0 0 0.5rem;
+        font-family: "Orbitron", sans-serif;
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.6rem 0.75rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .toggle-row button {
+        all: unset;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        padding: 0.45rem 0.75rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, rgba(24, 241, 255, 0.85), rgba(76, 106, 255, 0.85));
+        color: var(--text-light);
+        font-family: "Rajdhani", sans-serif;
+        font-size: 0.85rem;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+        transition: transform 160ms ease, box-shadow 160ms ease;
+      }
+
+      .toggle-row button[aria-pressed="true"] {
+        box-shadow: 0 0 18px rgba(24, 241, 255, 0.5);
+      }
+
+      .toggle-row button:hover,
+      .toggle-row button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 0 18px rgba(24, 241, 255, 0.65);
+        outline: none;
+      }
+
+      .settings-menu a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.65rem 0.85rem;
+        border-radius: 12px;
+        text-decoration: none;
+        color: var(--text-light);
+        font-family: "Rajdhani", sans-serif;
+        font-size: 0.95rem;
+        letter-spacing: 0.05em;
+        background: linear-gradient(120deg, rgba(255, 64, 246, 0.85), rgba(116, 29, 255, 0.85));
+        box-shadow: 0 0 20px rgba(255, 64, 246, 0.5);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+      }
+
+      .settings-menu a:hover,
+      .settings-menu a:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 0 26px rgba(255, 64, 246, 0.7);
+        outline: none;
+      }
+
+      .audio-prompt {
+        position: fixed;
+        left: 50%;
+        bottom: 2.5rem;
+        transform: translateX(-50%);
+        padding: 0.75rem 1.15rem;
+        border-radius: 999px;
+        background: rgba(10, 10, 30, 0.75);
+        border: 1px solid rgba(24, 241, 255, 0.4);
+        font-size: 0.95rem;
+        letter-spacing: 0.04em;
+        display: none;
+        align-items: center;
+        gap: 0.6rem;
+        box-shadow: 0 12px 25px rgba(3, 6, 28, 0.45);
+      }
+
+      .audio-prompt.active {
+        display: inline-flex;
+      }
+
+      .audio-prompt svg {
+        width: 1.1rem;
+        height: 1.1rem;
+        fill: currentColor;
+        color: var(--secondary);
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(-6px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      @media (max-width: 600px) {
+        .settings-wrapper {
+          top: 1rem;
+          right: 1rem;
+        }
+
+        .branding h1 {
+          letter-spacing: 0.08em;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <video
+      class="bg-video"
+      src="../elearn/worlds/kindercoder/thumbs/start-bg-loop.mp4"
+      autoplay
+      muted
+      loop
+      playsinline
+    ></video>
+    <div class="backdrop" aria-hidden="true"></div>
+
+    <div class="settings-wrapper">
+      <button class="settings-toggle" type="button" data-settings-toggle>
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 8.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Zm8.92 3.07-1.53-.88.05-.62a1.5 1.5 0 0 0-.74-1.4l-1.3-.75-.19-.59a1.5 1.5 0 0 0-1.43-1.04l-1.5.02-.45-.45a1.5 1.5 0 0 0-2.12 0l-.44.44-1.51-.02a1.5 1.5 0 0 0-1.44 1.04l-.18.6-1.3.75a1.5 1.5 0 0 0-.74 1.4l.05.62-1.53.88a1.5 1.5 0 0 0-.55 2.05l.75 1.3-.2.6a1.5 1.5 0 0 0 1.04 1.43l1.52.46.04.62a1.5 1.5 0 0 0 1.5 1.38h1.53l.44.44a1.5 1.5 0 0 0 2.12 0l.44-.44h1.54a1.5 1.5 0 0 0 1.5-1.38l.04-.62 1.52-.46a1.5 1.5 0 0 0 1.04-1.43l-.2-.6.75-1.3a1.5 1.5 0 0 0-.55-2.05Zm-2.54 3.05-.65 1.12.17.5c.05.16-.04.33-.2.38l-1.35.41-.04.54a.5.5 0 0 1-.5.46h-1.37l-.4.4a.5.5 0 0 1-.71 0l-.4-.4h-1.36a.5.5 0 0 1-.5-.46l-.04-.54-1.35-.41a.32.32 0 0 1-.2-.38l.17-.5-.65-1.13a.32.32 0 0 1 .12-.44l1.13-.65-.04-.54a.5.5 0 0 1 .25-.46l1.17-.68.16-.51a.5.5 0 0 1 .48-.35h1.37l.4-.4a.5.5 0 0 1 .71 0l.4.4h1.36a.5.5 0 0 1 .49.35l.16.51 1.17.68a.5.5 0 0 1 .25.46l-.04.54 1.13.65a.32.32 0 0 1 .12.44Z"
+          ></path>
+        </svg>
+        Settings
+      </button>
+      <div class="settings-menu" data-settings-menu aria-hidden="true">
+        <h2>Settings</h2>
+        <div class="toggle-row">
+          <span>Audio</span>
+          <button type="button" data-sound-toggle aria-pressed="false">
+            <span data-sound-icon aria-hidden="true">🔇</span>
+            <span data-sound-label>Sound Off</span>
+          </button>
+        </div>
+        <a href="../login.html">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0 2c-2.67 0-8 1.34-8 4v1.5c0 .28.22.5.5.5h15c.28 0 .5-.22.5-.5V18c0-2.66-5.33-4-8-4Z"
+            ></path>
+          </svg>
+          Login / Signup
+        </a>
+      </div>
+    </div>
+
+    <main class="content">
+      <div class="branding">
+        <h1>Queen's Academy</h1>
+        <p>
+          Embark on an intergalactic quest to master Calistung. Power up your
+          skills and get ready to play!
+        </p>
+      </div>
+      <div class="actions">
+        <a class="cta-button" href="../elearn/worlds/calistung/index.html">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="m8 5 11 7-11 7V5Z"></path>
+          </svg>
+          Start Game
+        </a>
+        <button class="cta-button secondary" type="button" data-settings-toggle-secondary>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M12 8.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Zm8.92 3.07-1.53-.88.05-.62a1.5 1.5 0 0 0-.74-1.4l-1.3-.75-.19-.59a1.5 1.5 0 0 0-1.43-1.04l-1.5.02-.45-.45a1.5 1.5 0 0 0-2.12 0l-.44.44-1.51-.02a1.5 1.5 0 0 0-1.44 1.04l-.18.6-1.3.75a1.5 1.5 0 0 0-.74 1.4l.05.62-1.53.88a1.5 1.5 0 0 0-.55 2.05l.75 1.3-.2.6a1.5 1.5 0 0 0 1.04 1.43l1.52.46.04.62a1.5 1.5 0 0 0 1.5 1.38h1.53l.44.44a1.5 1.5 0 0 0 2.12 0l.44-.44h1.54a1.5 1.5 0 0 0 1.5-1.38l.04-.62 1.52-.46a1.5 1.5 0 0 0 1.04-1.43l-.2-.6.75-1.3a1.5 1.5 0 0 0-.55-2.05Z"
+            ></path>
+          </svg>
+          Settings
+        </button>
+      </div>
+    </main>
+
+    <div class="audio-prompt" id="audioPrompt" role="status">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 3a1 1 0 0 1 .86.49l.08.16 1.53 3.46 3.79.33a1 1 0 0 1 .52 1.74l-.13.1-2.9 2.42.87 3.7a1 1 0 0 1-1.42 1.1l-.16-.08-3.04-1.84-3.04 1.84a1 1 0 0 1-1.48-1.02l.03-.16.87-3.7-2.9-2.41a1 1 0 0 1 .41-1.75l.16-.03 3.78-.33 1.54-3.46A1 1 0 0 1 12 3Z"
+        ></path>
+      </svg>
+      Tap anywhere to enable sound
+    </div>
+
+    <audio id="themeAudio" src="../elearn/worlds/calistung/thumbs/theme-song.mp3" loop></audio>
+
+    <script>
+      (function () {
+        const settingsButtons = document.querySelectorAll('[data-settings-toggle], [data-settings-toggle-secondary]');
+        const settingsMenu = document.querySelector('[data-settings-menu]');
+        const audioEl = document.getElementById('themeAudio');
+        const audioToggle = document.querySelector('[data-sound-toggle]');
+        const audioLabel = document.querySelector('[data-sound-label]');
+        const audioIcon = document.querySelector('[data-sound-icon]');
+        const audioPrompt = document.getElementById('audioPrompt');
+        let settingsOpen = false;
+
+        const openSettings = (open) => {
+          settingsOpen = open;
+          if (settingsOpen) {
+            settingsMenu.classList.add('active');
+            settingsMenu.setAttribute('aria-hidden', 'false');
+          } else {
+            settingsMenu.classList.remove('active');
+            settingsMenu.setAttribute('aria-hidden', 'true');
+          }
+        };
+
+        settingsButtons.forEach((button) => {
+          button.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openSettings(!settingsOpen);
+          });
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!settingsMenu.contains(event.target)) {
+            openSettings(false);
+          }
+        });
+
+        const updateAudioUI = () => {
+          const isMuted = audioEl.muted || audioEl.paused;
+          if (isMuted) {
+            audioToggle.setAttribute('aria-pressed', 'false');
+            audioLabel.textContent = 'Sound Off';
+            audioIcon.textContent = '🔇';
+          } else {
+            audioToggle.setAttribute('aria-pressed', 'true');
+            audioLabel.textContent = 'Sound On';
+            audioIcon.textContent = '🔊';
+          }
+        };
+
+        const tryPlayAudio = () => {
+          audioEl.volume = 0.65;
+          audioEl.muted = false;
+          const playPromise = audioEl.play();
+          if (playPromise && typeof playPromise.then === 'function') {
+            playPromise
+              .then(() => {
+                audioPrompt.classList.remove('active');
+                updateAudioUI();
+              })
+              .catch(() => {
+                audioEl.muted = true;
+                audioPrompt.classList.add('active');
+                updateAudioUI();
+              });
+          }
+        };
+
+        audioToggle.addEventListener('click', () => {
+          if (audioEl.paused) {
+            tryPlayAudio();
+            return;
+          }
+
+          audioEl.muted = !audioEl.muted;
+          if (!audioEl.muted) {
+            audioEl.play().catch(() => {
+              audioEl.muted = true;
+            });
+          }
+          updateAudioUI();
+        });
+
+        document.addEventListener(
+          'pointerdown',
+          () => {
+            if (audioEl.paused) {
+              tryPlayAudio();
+            } else if (audioEl.muted) {
+              audioEl.muted = false;
+              audioEl
+                .play()
+                .then(() => {
+                  audioPrompt.classList.remove('active');
+                  updateAudioUI();
+                })
+                .catch(() => {
+                  audioEl.muted = true;
+                  audioPrompt.classList.add('active');
+                  updateAudioUI();
+                });
+            }
+          },
+          { once: true }
+        );
+
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'visible' && !audioEl.paused && audioEl.muted) {
+            audioEl.muted = false;
+            audioEl.play().catch(() => {
+              audioEl.muted = true;
+            });
+            updateAudioUI();
+          }
+        });
+
+        tryPlayAudio();
+        updateAudioUI();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Queens Academy start page served from /queensacademy.id/start.html
- play the Calistung theme song with a mute toggle and prompt when sound is blocked
- provide start and settings controls with a login/signup shortcut and neon styling over a looping video background
- ensure the background video, theme music, and navigation links resolve reliably with relative asset paths

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbd65dce48832586ea8e80a1b09e7d