### PR TITLE
Fix manual blackout to hide orb and surface exit control

### DIFF
--- a/magicmirror-node/public/mmfront.html
+++ b/magicmirror-node/public/mmfront.html
@@ -114,6 +114,39 @@
       color:#eafbf6; display:grid; place-items:center; cursor:pointer;
       box-shadow:0 8px 22px rgba(0,0,0,.35);
     }
+    .blackout-exit{
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      width: 44px;
+      height: 44px;
+      border-radius: 999px;
+      border: 1px solid rgba(233,196,106,.45);
+      background: linear-gradient(135deg, rgba(255,255,255,.18), rgba(255,255,255,.04));
+      color:#fdf8e6;
+      display:grid;
+      place-items:center;
+      font-size:1.05rem;
+      cursor:pointer;
+      box-shadow:0 10px 26px rgba(0,0,0,.45);
+      opacity:0;
+      pointer-events:none;
+      transition: opacity .25s ease, transform .25s ease;
+      z-index:10000;
+    }
+    .blackout-exit:hover{ transform: translateY(-2px); }
+    .blackout-exit:focus-visible{ outline:2px solid var(--accent); outline-offset:3px; }
+    .blackout-exit.is-visible{
+      opacity:1;
+      pointer-events:auto;
+    }
+    body.manual-blackout .blackout-exit{
+      opacity:1;
+      pointer-events:auto;
+    }
+    .manual-blackout-hidden{
+      display:none !important;
+    }
     .controls.hidden{ opacity:0; pointer-events:none; transform: translate(-50%, 12px); }
     .controls{ transition: opacity .22s ease, transform .22s ease; }
     body.idle-blackout .controls-toggle{ opacity:0; pointer-events:none; }
@@ -590,6 +623,33 @@ body.idle-blackout .caption{ opacity: 0 !important; }
     opacity: 0 !important;
     pointer-events: none !important;
   }
+  body.manual-blackout {
+    background: #000 !important;
+  }
+  body.manual-blackout::before,
+  body.manual-blackout::after {
+    opacity: 0 !important;
+  }
+  body.manual-blackout #ai-avatar {
+    display: none !important;
+  }
+  body.manual-blackout #holo-embed {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  body.manual-blackout .mm-ui,
+  body.manual-blackout .hud,
+  body.manual-blackout #navbar,
+  body.manual-blackout #footer-placeholder,
+  body.manual-blackout #lightbox,
+  body.manual-blackout #vc-toast,
+  body.manual-blackout #ai-chat,
+  body.manual-blackout #lux-particles,
+  body.manual-blackout #controls-toggle,
+  body.manual-blackout #vc-toggle {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
   /* Keep only orb visible and centered with gentle patrol */
   body.idle-blackout #ai-avatar {
     --tx: 0px; --ty: 0px; /* neutralize eye-follow while idle */
@@ -881,10 +941,12 @@ h1{
           <button id="capture-button" class="btn">Analyze Style</button>
           <button id="flip-mirror" class="btn secondary" title="Flip preview horizontally">Flip Mirror</button>
           <button id="fullscreen" class="btn secondary" title="Fullscreen mode">Fullscreen</button>
+          <button id="blackout-button" class="btn danger" type="button" title="Gelapkan seluruh layar">Gelapkan Layar</button>
         </div>
         <button id="controls-toggle" class="controls-toggle" aria-pressed="true" title="Hide controls">▾</button>
         <button id="vc-toggle" class="vc-toggle" aria-pressed="false" title="Enable voice command">🎙️</button>
     <div id="vc-toast" class="vc-toast" style="display:none;">Say: “Hey Mirror…”</div>
+    <button id="blackout-exit" class="blackout-exit" type="button" title="Kembalikan tampilan" aria-label="Kembalikan tampilan" aria-hidden="true" tabindex="-1">☀️</button>
     <script>
 // === Voice Command: Hey Mirror → (camera on) → commands (mulai analisa/analyze) ===
 (function(){
@@ -1847,6 +1909,99 @@ function renderAnalysis(analysis){
           (el.requestFullscreen || el.webkitRequestFullscreen || el.msRequestFullscreen).call(el);
         } else {
           (document.exitFullscreen || document.webkitExitFullscreen || document.msExitFullscreen).call(document);
+        }
+      });
+    })();
+    // Manual blackout toggle
+    (function(){
+      const blackoutBtn = document.getElementById('blackout-button');
+      const exitBtn = document.getElementById('blackout-exit');
+      if(!blackoutBtn || !exitBtn) return;
+      const body = document.body;
+      if(exitBtn.parentElement !== body){
+        try{ body.appendChild(exitBtn); }catch(_){ /* ignore append issues */ }
+      }
+      let restoreIdle = false;
+      let previousFocus = null;
+
+      function toggleManualHidden(on){
+        const targets = ['ai-avatar', 'holo-embed'].map((id)=>{
+          const el = document.getElementById(id);
+          return el ? el : null;
+        }).filter(Boolean);
+        targets.forEach((el)=>{
+          if(on){
+            if(!el.dataset.manualBlackoutAria){
+              el.dataset.manualBlackoutAria = el.getAttribute('aria-hidden') ?? '';
+            }
+          }
+          el.classList.toggle('manual-blackout-hidden', on);
+          const prev = el.dataset.manualBlackoutAria;
+          if(on){
+            el.setAttribute('aria-hidden', 'true');
+          } else if(prev !== undefined){
+            if(prev === ''){
+              el.removeAttribute('aria-hidden');
+            } else {
+              el.setAttribute('aria-hidden', prev);
+            }
+            delete el.dataset.manualBlackoutAria;
+          }
+        });
+      }
+
+      function enter(){
+        if(body.classList.contains('manual-blackout')) return;
+        restoreIdle = !body.classList.contains('idle-blackout');
+        body.classList.add('manual-blackout');
+        body.classList.add('idle-blackout');
+        previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        toggleManualHidden(true);
+        exitBtn.classList.add('is-visible');
+        exitBtn.setAttribute('aria-hidden', 'false');
+        exitBtn.setAttribute('tabindex', '0');
+        requestAnimationFrame(()=>{
+          try{ exitBtn.focus({ preventScroll: true }); }
+          catch(_){ try{ exitBtn.focus(); }catch(__){} }
+        });
+      }
+      function exit(){
+        if(!body.classList.contains('manual-blackout')) return;
+        body.classList.remove('manual-blackout');
+        if(restoreIdle){
+          body.classList.remove('idle-blackout');
+        }
+        restoreIdle = false;
+        toggleManualHidden(false);
+        exitBtn.classList.remove('is-visible');
+        exitBtn.setAttribute('aria-hidden', 'true');
+        exitBtn.setAttribute('tabindex', '-1');
+        if(previousFocus && previousFocus.isConnected && previousFocus !== document.body){
+          try{ previousFocus.focus({ preventScroll: true }); }
+          catch(_){ try{ previousFocus.focus(); }catch(__){} }
+        }
+        previousFocus = null;
+      }
+      blackoutBtn.addEventListener('click', ()=>{
+        if(body.classList.contains('manual-blackout')){
+          exit();
+        } else {
+          enter();
+        }
+      });
+      exitBtn.addEventListener('click', (e)=>{
+        e.preventDefault();
+        exit();
+      });
+      exitBtn.addEventListener('keydown', (e)=>{
+        if((e.key === 'Enter' || e.key === ' ') && body.classList.contains('manual-blackout')){
+          e.preventDefault();
+          exit();
+        }
+      });
+      document.addEventListener('keydown', (e)=>{
+        if(e.key === 'Escape'){
+          exit();
         }
       });
     })();


### PR DESCRIPTION
## Summary
- ensure manual blackout fully hides the AI orb and hologram iframe by applying a reusable blackout-hidden class and extra CSS safeguards
- make the blackout exit button explicitly visible during manual mode and return focus to the previous control after restoring the UI
- guard the blackout exit control placement so it always sits at the body root and is focusable for keyboard users

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ced64a14832582e0771030c97044