### PR TITLE
Limit scroll guard keywords to tracing surfaces

### DIFF
--- a/magicmirror-node/public/elearn/common/calistung-navbar.js
+++ b/magicmirror-node/public/elearn/common/calistung-navbar.js
@@ -138,7 +138,7 @@
       window.__calistungScrollGuardInitialized = true;
 
       const activePointers = new Set();
-      const KEYWORD_RE = /(canvas|board|grid|trace|draw|drag|drop|worksheet|work|play|game|zone|pad|field|workspace|arena|touch|paint|scribble|math|shape|alphabet|number|sorting|matching|connect|line|write|warna|gambar|susun|urut|angk|huruf)/i;
+      const KEYWORD_RE = /(canvas|trace|draw|touch|paint|scribble|write|tulis|warna|gambar)/i;
       const IGNORE_SELECTOR = '.calistung-navbar, .finish-bar, .hud-bar, .hud-panel, [data-allow-scroll], [data-scrollable]';
 
       const style = document.createElement('style');


### PR DESCRIPTION
## Summary
- narrow the calistung scroll guard keyword list to tracing-related terms so non-tracing areas remain scrollable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba655ffb08325bf52a23245901f33