### PR TITLE
Add Python CLI fallback for hair recolor service

### DIFF
--- a/magicmirror-node/public/mmfront.html
+++ b/magicmirror-node/public/mmfront.html
@@ -390,6 +390,178 @@ body.idle-blackout .caption{ opacity: 0 !important; }
             transition: transform 0.3s ease;
         }
 
+        .gallery-card.is-active {
+            outline: 2px solid var(--accent);
+            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12), 0 16px 32px rgba(0, 0, 0, 0.45);
+            transform: translateY(-6px);
+        }
+
+        .gallery-card.is-active img {
+            transform: scale(1.05);
+        }
+
+        /* === Hair Color Panel (UI block for hair recolor controls) === */
+        #hair-color-panel {
+            display: none;
+            margin-top: 16px;
+            padding: 18px;
+            gap: 14px;
+            color: #eafbf6;
+        }
+
+        #hair-color-panel .hair-panel-top {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: flex-start;
+            gap: 18px;
+        }
+
+        #hair-color-panel .hair-panel-heading {
+            flex: 1 1 220px;
+        }
+
+        #hair-color-panel .hair-title {
+            font-weight: 700;
+            font-size: 1.15rem;
+            color: var(--accent);
+            margin-bottom: 4px;
+        }
+
+        #hair-color-panel .hair-status {
+            font-size: 0.86rem;
+            opacity: 0.85;
+            color: #cffff0;
+            transition: color 0.2s ease;
+        }
+
+        #hair-color-panel .hair-status[data-state="busy"] {
+            color: #ffdd57;
+        }
+
+        #hair-color-panel .hair-status[data-state="error"] {
+            color: var(--danger);
+        }
+
+        #hair-color-panel .hair-preview-wrap {
+            flex: 0 0 auto;
+        }
+
+        #hair-preview {
+            display: none;
+            width: 180px;
+            max-width: 100%;
+            border-radius: 16px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+        }
+
+        #hair-color-panel .hair-swatches {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 14px;
+        }
+
+        .hair-color-swatch {
+            width: 46px;
+            height: 46px;
+            border-radius: 14px;
+            border: 2px solid rgba(255, 255, 255, 0.16);
+            cursor: pointer;
+            position: relative;
+            transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+            background-size: cover;
+        }
+
+        .hair-color-swatch::after {
+            content: attr(data-label);
+            position: absolute;
+            left: 50%;
+            top: calc(100% + 6px);
+            transform: translateX(-50%);
+            font-size: 0.7rem;
+            color: #eafbf6;
+            white-space: nowrap;
+            pointer-events: none;
+        }
+
+        .hair-color-swatch.is-active {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25), 0 12px 24px rgba(0, 0, 0, 0.45);
+            transform: translateY(-3px);
+        }
+
+        #hair-color-panel .hair-controls {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            margin-top: 12px;
+        }
+
+        #hair-color-panel .hair-strength {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        #hair-color-panel .hair-strength label {
+            font-size: 0.9rem;
+            color: #cffff0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        #hair-strength {
+            width: 100%;
+            accent-color: var(--accent);
+        }
+
+        #hair-color-panel .hair-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        #hair-color-panel button.hair-custom-btn {
+            padding: 10px 16px;
+            border-radius: 12px;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06));
+            color: #f4fff8;
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            cursor: pointer;
+            font-weight: 600;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        #hair-color-panel button.hair-custom-btn:hover {
+            transform: translateY(-1px);
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.1));
+        }
+
+        #hair-color-panel button.hair-custom-btn.is-active {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25), 0 12px 24px rgba(0, 0, 0, 0.45);
+        }
+
+        #hair-color-panel.is-busy {
+            opacity: 0.72;
+            pointer-events: none;
+        }
+
+        @media (max-width: 768px) {
+            #hair-color-panel .hair-panel-top {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            #hair-preview {
+                width: 100%;
+            }
+        }
+
         @media (max-width: 480px) {
             body {
                 font-size: 14px;
@@ -1154,11 +1326,41 @@ h1{
             <h2>Rekomendasi Gaya Rambut</h2>
             <p id="rec-content"></p>
         </div>
+        <!-- Hair Color Panel UI — Hair recoloring presets + preview -->
+        <div id="hair-color-panel" class="glass">
+          <div class="hair-panel-top">
+            <div class="hair-panel-heading">
+              <div class="hair-title">Hair Color</div>
+              <div id="hair-color-status" class="hair-status" data-state="ready">Ready</div>
+            </div>
+            <div class="hair-preview-wrap">
+              <img id="hair-preview" alt="Hair color preview" decoding="async" />
+            </div>
+          </div>
+          <div class="hair-controls">
+            <div id="hair-color-swatches" class="hair-swatches" role="group" aria-label="Hair color presets">
+              <button type="button" class="hair-color-swatch" data-hex="#8A7E72" data-label="Ash Brown" aria-label="Ash Brown" style="background:#8A7E72;"></button>
+              <button type="button" class="hair-color-swatch" data-hex="#E6A3A1" data-label="Rose Gold" aria-label="Rose Gold" style="background:#E6A3A1;"></button>
+              <button type="button" class="hair-color-swatch" data-hex="#70193D" data-label="Burgundy" aria-label="Burgundy" style="background:#70193D;"></button>
+              <button type="button" class="hair-color-swatch" data-hex="#2F8F9D" data-label="Blue Teal" aria-label="Blue Teal" style="background:#2F8F9D;"></button>
+              <button type="button" class="hair-color-swatch" data-hex="#EAEAEA" data-label="Platinum" aria-label="Platinum" style="background:#EAEAEA;"></button>
+              <button type="button" class="hair-color-swatch" data-hex="#4C2A85" data-label="Dark Violet" aria-label="Dark Violet" style="background:#4C2A85;"></button>
+            </div>
+            <div class="hair-footer">
+              <button type="button" id="hair-color-custom" class="hair-custom-btn" data-label="Custom color">Custom…</button>
+              <div class="hair-strength">
+                <label for="hair-strength">Strength <span id="hair-strength-value">0.80</span></label>
+                <input type="range" id="hair-strength" min="0" max="1" step="0.05" value="0.8" />
+              </div>
+            </div>
+            <input type="color" id="hair-color-picker" value="#8A7E72" style="display:none;" aria-label="Pick custom hair color" />
+          </div>
+        </div>
         <!-- WhatsApp Share UI -->
         <div id="wa-share" class="glass" style="display:none; margin-top:12px; padding:12px;">
           <div style="font-weight:700; color: var(--accent); margin-bottom:8px;">Kirim hasil ke WhatsApp</div>
           <div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
-            <input id="wa-phone" type="tel" inputmode="numeric" placeholder="Nomor WhatsApp (contoh: 62812xxxx)" 
+            <input id="wa-phone" type="tel" inputmode="numeric" placeholder="Nomor WhatsApp (contoh: 62812xxxx)"
                    style="flex:1; min-width:220px; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.08); color:#eafffb;"/>
             <button id="wa-send" class="btn" type="button">Kirim WhatsApp</button>
           </div>
@@ -1283,6 +1485,283 @@ window.addEventListener('DOMContentLoaded', ()=>{
   bN && bN.addEventListener('click', ()=> openApp('netflix'));
   bS && bS.addEventListener('click', ()=> openApp('spotify'));
 });
+        </script>
+        <script>
+        // === Hair Color Panel Controller (hair recolor UI + backend integration) ===
+        (function(){
+          const panel = document.getElementById('hair-color-panel');
+          if(!panel) return;
+          const statusEl = document.getElementById('hair-color-status');
+          const preview = document.getElementById('hair-preview');
+          const swatchWrap = document.getElementById('hair-color-swatches');
+          const customBtn = document.getElementById('hair-color-custom');
+          const customPicker = document.getElementById('hair-color-picker');
+          const strength = document.getElementById('hair-strength');
+          const strengthValue = document.getElementById('hair-strength-value');
+          let panelVisible = false;
+          let busy = false;
+          let baseOriginal = null;
+          let allowAutoBase = true;
+          let activeGalleryCard = null;
+
+          function updateStrengthLabel(){
+            if(!strength || !strengthValue) return;
+            const val = parseFloat(strength.value || '0');
+            strengthValue.textContent = val.toFixed(2);
+          }
+
+          function setStatus(text, state, detail){
+            if(!statusEl) return;
+            const st = state || 'ready';
+            statusEl.textContent = text;
+            statusEl.dataset.state = st;
+            if(detail){ statusEl.title = detail; }
+            else { statusEl.removeAttribute('title'); }
+          }
+
+          function setBusy(on){
+            busy = !!on;
+            panel.classList.toggle('is-busy', busy);
+            if(swatchWrap){
+              swatchWrap.querySelectorAll('button').forEach(btn => { btn.disabled = busy; });
+            }
+            if(customBtn) customBtn.disabled = busy;
+            if(strength) strength.disabled = busy;
+          }
+
+          function ensureVisible(){
+            if(panelVisible) return;
+            panel.style.display = 'block';
+            panelVisible = true;
+          }
+
+          function hidePanel(){
+            panel.style.display = 'none';
+            panelVisible = false;
+          }
+
+          function highlightColorButton(btn){
+            if(!swatchWrap) return;
+            swatchWrap.querySelectorAll('.hair-color-swatch').forEach(el => el.classList.remove('is-active'));
+            if(btn){
+              btn.classList.add('is-active');
+              if(customBtn) customBtn.classList.remove('is-active');
+            }
+          }
+
+          function setCustomActive(hex){
+            highlightColorButton(null);
+            if(customBtn){
+              customBtn.classList.add('is-active');
+              if(hex) customBtn.dataset.hex = hex;
+            }
+            if(customPicker && hex && /^#[0-9A-F]{6}$/i.test(hex)){
+              customPicker.value = hex;
+            }
+          }
+
+          function highlightGalleryCard(card){
+            if(activeGalleryCard === card) return;
+            if(activeGalleryCard) activeGalleryCard.classList.remove('is-active');
+            activeGalleryCard = card || null;
+            if(activeGalleryCard) activeGalleryCard.classList.add('is-active');
+          }
+
+          function resetPanel(){
+            baseOriginal = null;
+            allowAutoBase = true;
+            setBusy(false);
+            hidePanel();
+            setStatus('Ready', 'ready');
+            if(preview){
+              preview.removeAttribute('src');
+              preview.style.display = 'none';
+            }
+            highlightColorButton(null);
+            if(customBtn) customBtn.classList.remove('is-active');
+            if(strength){
+              const initial = strength.getAttribute('value');
+              if(initial != null) strength.value = initial;
+              updateStrengthLabel();
+            }
+            highlightGalleryCard(null);
+          }
+
+          async function imageElementToDataUrl(img){
+            return new Promise((resolve, reject) => {
+              if(!img){ reject(new Error('Image element missing')); return; }
+              const finalize = () => {
+                try{
+                  const canvas = document.createElement('canvas');
+                  const w = img.naturalWidth || img.width;
+                  const h = img.naturalHeight || img.height;
+                  if(!w || !h) throw new Error('Empty image dimensions');
+                  canvas.width = w;
+                  canvas.height = h;
+                  const ctx = canvas.getContext('2d');
+                  ctx.drawImage(img, 0, 0, w, h);
+                  resolve(canvas.toDataURL('image/jpeg', 0.98));
+                }catch(err){
+                  const src = img.currentSrc || img.src;
+                  if(!src){ reject(err); return; }
+                  fetch(new URL(src, window.location.href), { cache: 'no-store', mode: 'cors', credentials: 'omit' })
+                    .then(resp => {
+                      if(!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                      return resp.blob();
+                    })
+                    .then(blob => new Promise((resolveBlob, rejectBlob) => {
+                      const reader = new FileReader();
+                      reader.onloadend = () => resolveBlob(reader.result);
+                      reader.onerror = () => rejectBlob(reader.error || new Error('Failed to read blob'));
+                      reader.readAsDataURL(blob);
+                    }))
+                    .then(resolve)
+                    .catch(reject);
+                }
+              };
+              if(!img.complete || !img.naturalWidth){
+                img.addEventListener('load', () => finalize(), { once:true });
+                img.addEventListener('error', () => reject(new Error('Image failed to load')), { once:true });
+                return;
+              }
+              finalize();
+            });
+          }
+
+          async function setBaseFromImage(img, opts){
+            const options = opts || {};
+            if(options.auto && !allowAutoBase && baseOriginal){
+              return;
+            }
+            try{
+              const dataUrl = await imageElementToDataUrl(img);
+              const base64 = dataUrl.replace(/^data:image\/\w+;base64,/, '');
+              if(!base64) throw new Error('Base64 kosong');
+              baseOriginal = base64;
+              if(preview){
+                preview.src = dataUrl;
+                preview.style.display = 'block';
+                preview.dataset.sourceLabel = options.label || '';
+              }
+              ensureVisible();
+              setStatus('Ready', 'ready');
+              highlightGalleryCard(img && img.closest('.gallery-card'));
+              if(options.auto){ allowAutoBase = false; }
+            }catch(err){
+              console.warn('hair preview error', err);
+              if(!baseOriginal){
+                setStatus('Error', 'error', err.message || 'Gagal menyiapkan foto dasar');
+              }
+            }
+          }
+
+          async function applyHairColor(hex, opts){
+            const rawHex = (hex || '').toString().trim();
+            if(!rawHex) return;
+            if(!baseOriginal){
+              setStatus('Error', 'error', 'Belum ada foto yang siap diwarnai');
+              return;
+            }
+            if(busy) return;
+            const normalized = rawHex.startsWith('#') ? rawHex : `#${rawHex}`;
+            const hexValid = /^#([0-9a-fA-F]{6})$/.test(normalized);
+            if(!hexValid){
+              setStatus('Error', 'error', 'Format warna tidak valid');
+              return;
+            }
+            const payload = {
+              imageBase64: baseOriginal,
+              hex: normalized.toUpperCase(),
+              strength: Math.max(0, Math.min(1, parseFloat(strength?.value ?? '0') || 0)),
+              label: opts && typeof opts.label === 'string' && opts.label.trim() ? opts.label.trim() : undefined
+            };
+            setStatus('Applying…', 'busy');
+            setBusy(true);
+            try{
+              const res = await fetch('/api/hair-color', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+              });
+              const data = await res.json().catch(() => null);
+              if(!res.ok){
+                const message = data && (data.error || data.message) ? (data.error || data.message) : `HTTP ${res.status}`;
+                throw new Error(message);
+              }
+              if(!data || !data.imageOutBase64){
+                throw new Error('Response tidak valid dari server');
+              }
+              const output = `data:image/jpeg;base64,${data.imageOutBase64}`;
+              if(preview){
+                preview.src = output;
+                preview.style.display = 'block';
+              }
+              setStatus('Ready', 'ready');
+            }catch(err){
+              console.error('hair color failed', err);
+              setStatus('Error', 'error', err.message || 'Gagal menerapkan warna');
+            }finally{
+              setBusy(false);
+            }
+          }
+
+          if(strength){
+            strength.addEventListener('input', updateStrengthLabel);
+            updateStrengthLabel();
+          }
+
+          if(swatchWrap){
+            swatchWrap.addEventListener('click', (event) => {
+              const btn = event.target.closest('.hair-color-swatch');
+              if(!btn || busy) return;
+              const hex = btn.dataset.hex;
+              if(!hex) return;
+              const label = btn.dataset.label || '';
+              highlightColorButton(btn);
+              applyHairColor(hex, { label });
+            });
+          }
+
+          if(customBtn && customPicker){
+            customBtn.addEventListener('click', () => {
+              if(busy) return;
+              customPicker.click();
+            });
+            customPicker.addEventListener('change', () => {
+              const hex = customPicker.value;
+              if(!hex) return;
+              setCustomActive(hex);
+              const label = customBtn.dataset.label || 'Custom color';
+              applyHairColor(hex, { label });
+            });
+            customPicker.addEventListener('input', () => {
+              if(document.activeElement === customPicker){
+                const hex = customPicker.value;
+                if(hex) setCustomActive(hex);
+              }
+            });
+          }
+
+          window.__hairPanelController = {
+            reset: resetPanel,
+            prepareForGallery: () => {
+              baseOriginal = null;
+              allowAutoBase = true;
+              setBusy(false);
+              hidePanel();
+              setStatus('Ready', 'ready');
+              if(preview){
+                preview.removeAttribute('src');
+                preview.style.display = 'none';
+              }
+              highlightColorButton(null);
+              if(customBtn) customBtn.classList.remove('is-active');
+              highlightGalleryCard(null);
+            },
+            setBaseFromImage: (img, opts) => setBaseFromImage(img, opts),
+            isVisible: () => panelVisible
+          };
+        })();
         </script>
         <!-- Detailed Analysis (Face Mesh + Skin Tone) -->
         <div id="analysis-detail" class="glass" style="display:none; margin-top:16px; padding:16px;">
@@ -1490,6 +1969,7 @@ document.getElementById('capture-button').addEventListener('click', async () => 
     try{ if(window.__analyzeAbort){ window.__analyzeAbort.abort(); } }catch(_){}
     const __ctrl = (typeof AbortController !== 'undefined') ? new AbortController() : null;
     window.__analyzeAbort = __ctrl;
+    try{ window.__hairPanelController && window.__hairPanelController.reset(); }catch(_){ }
             const video = window.getCaptureVideo ? window.getCaptureVideo() : document.getElementById('camera-preview');
             if(window.ensureVideoReady){ await window.ensureVideoReady(video, 2200); }
             const vw = video && video.videoWidth ? video.videoWidth : 640;
@@ -1573,13 +2053,24 @@ document.getElementById('capture-button').addEventListener('click', async () => 
                     setStatus('✅ Rekomendasi siap!', '#00ff99');
 
                     if (data.faces && data.faces.length > 0) {
+                        try{ window.__hairPanelController && window.__hairPanelController.prepareForGallery(); }catch(_){ }
                         const gallery = document.getElementById('gallery');
                         data.faces.forEach((url, index) => {
                             const card = document.createElement('div');
                             card.className = 'gallery-card fade-in-stagger';
                             card.style.animationDelay = `${index * 0.2}s`;
                             const img = document.createElement('img');
+                            img.crossOrigin = 'anonymous';
+                            img.decoding = 'async';
+                            img.loading = 'lazy';
                             img.src = url.startsWith('http') ? url : `https://qc-magicmirror-api.onrender.com${url}`;
+                            const label = `Face ${index + 1}`;
+                            img.alt = label;
+                            img.dataset.faceLabel = label;
+                            img.addEventListener('load', () => {
+                                try{ window.__hairPanelController && window.__hairPanelController.setBaseFromImage(img, { label, auto: true }); }
+                                catch(_){ }
+                            }, { once: true });
                             card.appendChild(img);
                             gallery.appendChild(card);
                         });
@@ -1707,12 +2198,23 @@ socket.on('generated_faces', (data) => {
         window.__facesShown = true;
         if (window.__genCountdownInterval) { clearInterval(window.__genCountdownInterval); window.__genCountdownInterval = null; }
         gallery.innerHTML = '';
+        try{ window.__hairPanelController && window.__hairPanelController.prepareForGallery(); }catch(_){ }
         validFaces.forEach((url, index) => {
             const card = document.createElement('div');
             card.className = 'gallery-card fade-in-stagger';
             card.style.animationDelay = `${index * 0.2}s`;
             const img = document.createElement('img');
+            img.crossOrigin = 'anonymous';
+            img.decoding = 'async';
+            img.loading = 'lazy';
             img.src = url;
+            const label = `Face ${index + 1}`;
+            img.alt = label;
+            img.dataset.faceLabel = label;
+            img.addEventListener('load', () => {
+                try{ window.__hairPanelController && window.__hairPanelController.setBaseFromImage(img, { label, auto: true }); }
+                catch(_){ }
+            }, { once: true });
             card.appendChild(img);
             gallery.appendChild(card);
         });
@@ -1831,13 +2333,29 @@ function renderAnalysis(analysis){
 }
 
 
-        // Lightbox for gallery images
-        document.getElementById('gallery').addEventListener('click', (e) => {
-            if (e.target.tagName === 'IMG') {
-                document.getElementById('lightbox-img').src = e.target.src;
-                document.getElementById('lightbox').style.display = 'flex';
-            }
-        });
+        // Lightbox for gallery images + bridge to hair color selector
+        (function(){
+            const galleryEl = document.getElementById('gallery');
+            const lightbox = document.getElementById('lightbox');
+            const lightboxImg = document.getElementById('lightbox-img');
+            if(!galleryEl) return;
+            galleryEl.addEventListener('click', (e) => {
+                if (!(e.target && e.target.tagName === 'IMG')) return;
+                const img = e.target;
+                const label = img.dataset.faceLabel || img.alt || '';
+                try{ window.__hairPanelController && window.__hairPanelController.setBaseFromImage(img, { label, auto: false }); }
+                catch(_){ }
+                const hairVisible = !!(window.__hairPanelController && window.__hairPanelController.isVisible && window.__hairPanelController.isVisible());
+                if (hairVisible && e.detail < 2) {
+                    e.preventDefault();
+                    return;
+                }
+                if (lightboxImg && lightbox) {
+                    lightboxImg.src = img.src;
+                    lightbox.style.display = 'flex';
+                }
+            });
+        })();
 
         document.getElementById('lightbox').addEventListener('click', () => {
             document.getElementById('lightbox').style.display = 'none';

--- a/magicmirror-node/server.js
+++ b/magicmirror-node/server.js
@@ -7,6 +7,8 @@ const http = require('http').createServer(app);
 const io = require('socket.io')(http, { cors: { origin: "*" } });
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
 const { google } = require('googleapis');
 const uploadModulRouter = require('./uploadModul');
 const admin = require('firebase-admin');
@@ -77,6 +79,122 @@ app.get('/api/version', (req, res) => {
   });
 });
 
+// === Hair Color API (hair recoloring endpoint bridging UI to Minimax/Replicate) ===
+app.post('/api/hair-color', async (req, res) => {
+  const started = Date.now();
+  const { imageBase64, hex, strength, label } = req.body || {};
+  const rawImage = typeof imageBase64 === 'string' ? imageBase64 : '';
+  const sanitizedImage = rawImage.replace(/^data:image\/\w+;base64,/, '').replace(/[\r\n\s]+/g, '');
+  let rawHex = typeof hex === 'string' ? hex.trim() : '';
+  if (!rawHex.startsWith('#')) rawHex = `#${rawHex}`;
+  const normalizedHex = rawHex.toUpperCase();
+  const strengthValue = Math.max(0, Math.min(1, Number(strength) || 0));
+  const labelNormalized = typeof label === 'string' && label.trim() ? label.trim() : null;
+
+  if (!sanitizedImage) {
+    return res.status(400).json({ ok: false, error: 'imageBase64 wajib diisi' });
+  }
+  if (!/^#[0-9A-F]{6}$/.test(normalizedHex)) {
+    return res.status(400).json({ ok: false, error: 'Format warna harus #RRGGBB' });
+  }
+
+  const colorDescriptor = describeHairColor(normalizedHex, labelNormalized);
+  const logMeta = { color: normalizedHex, strength: strengthValue, label: colorDescriptor };
+  let serviceUsed = 'replicate';
+  const timeoutMs = Number(process.env.HAIR_COLOR_TIMEOUT_MS || 120000);
+  const delegateCandidates = [];
+  const explicitDelegate = process.env.HAIR_COLOR_SERVICE_URL && process.env.HAIR_COLOR_SERVICE_URL.trim();
+  const allowLocal = process.env.HAIR_COLOR_DISABLE_LOCAL !== '1';
+  if (explicitDelegate) {
+    delegateCandidates.push(explicitDelegate);
+  } else if (allowLocal) {
+    delegateCandidates.push('http://127.0.0.1:10000/api/hair-color');
+  }
+  let delegateError = null;
+  let cliError = null;
+
+  try {
+    console.log('[hair-color] start', logMeta);
+    let imageOutBase64;
+    if (delegateCandidates.length) {
+      for (const delegateUrl of delegateCandidates) {
+        try {
+          serviceUsed = 'delegate';
+          const { data } = await axios.post(delegateUrl, {
+            imageBase64: sanitizedImage,
+            hex: normalizedHex,
+            strength: strengthValue,
+            label: labelNormalized || colorDescriptor
+          }, { timeout: timeoutMs });
+          if (data && data.ok === false) {
+            throw new Error(data.error || 'Delegate hair color error');
+          }
+          const remote = data && (data.imageOutBase64 || data.image_base64 || data.image || data.result);
+          if (!remote) {
+            throw new Error('Layanan hair color tidak mengembalikan field imageOutBase64');
+          }
+          imageOutBase64 = String(remote).replace(/^data:image\/\w+;base64,/, '').replace(/[\r\n\s]+/g, '');
+          delegateError = null;
+          break;
+        } catch (delegateErr) {
+          delegateError = delegateErr;
+          console.warn('[hair-color] delegate failed, considering fallback', {
+            ...logMeta,
+            service: 'delegate',
+            url: delegateUrl,
+            error: delegateErr.message || delegateErr
+          });
+        }
+      }
+    }
+    if (!imageOutBase64) {
+      try {
+        imageOutBase64 = await runHairColorViaPythonCli(sanitizedImage, normalizedHex, strengthValue, {
+          label: labelNormalized || colorDescriptor
+        });
+        serviceUsed = 'python-cli';
+      } catch (pyCliErr) {
+        cliError = pyCliErr;
+        if (pyCliErr && pyCliErr.message) {
+          console.warn('[hair-color] python cli failed, considering replicate fallback', {
+            ...logMeta,
+            service: 'python-cli',
+            error: pyCliErr.message
+          });
+        }
+      }
+    }
+    if (!imageOutBase64) {
+      serviceUsed = 'replicate';
+      try {
+        imageOutBase64 = await runHairColorViaReplicate(sanitizedImage, normalizedHex, strengthValue, { colorDescriptor });
+      } catch (replicateErr) {
+        if (delegateError) {
+          throw delegateError;
+        }
+        if (cliError) {
+          throw cliError;
+        }
+        throw replicateErr;
+      }
+    }
+    console.log('[hair-color] success', { ...logMeta, service: serviceUsed, ms: Date.now() - started });
+    res.json({ ok: true, imageOutBase64 });
+  } catch (err) {
+    const responsePayload = err && err.response && err.response.data;
+    const message = (responsePayload && (responsePayload.error || responsePayload.message)) || (err && err.message ? err.message : 'Hair color processing failed');
+    const enriched = { ...logMeta, service: serviceUsed, ms: Date.now() - started, error: message, detail: responsePayload || null };
+    if (delegateError && serviceUsed === 'replicate') {
+      enriched.delegateError = delegateError.message || String(delegateError);
+    }
+    if (cliError && serviceUsed === 'replicate') {
+      enriched.pythonCliError = cliError.message || String(cliError);
+    }
+    console.error('[hair-color] error', enriched);
+    res.status(500).json({ ok: false, error: message });
+  }
+});
+
 async function postToGAS(tabName, dataArray) {
   const GAS_URL = process.env.WEB_APP_URL || 'https://script.google.com/macros/s/AKfycbynFv8gTnczc7abTL5Olq_sKmf1e0y6w9z_KBTKETK8i6NaGd941Cna4QVnoujoCsMdvA/exec';
   if (!GAS_URL.startsWith('http')) {
@@ -113,6 +231,258 @@ async function postAllToGAS(datasets) {
   } catch {
     console.error('Invalid JSON from GAS:', text);
     throw new Error('GAS did not return valid JSON');
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function ensureReplicateReference(imageBase64, replicateToken) {
+  const buffer = Buffer.from(imageBase64, 'base64');
+  if (!buffer.length) {
+    throw new Error('Gambar dasar kosong.');
+  }
+  const fileLabel = `hair-${Date.now()}-${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)}.jpg`;
+  const initResp = await axios.post('https://api.replicate.com/v1/files', { filename: fileLabel, name: fileLabel }, {
+    headers: {
+      Authorization: `Token ${replicateToken}`,
+      'Content-Type': 'application/json'
+    },
+    timeout: 15000
+  });
+  const initData = initResp && initResp.data ? initResp.data : null;
+  const uploadUrl = initData && (initData.upload_url || (initData.urls && initData.urls.upload));
+  const downloadUrl = initData && (initData.download_url || (initData.urls && initData.urls.get));
+  if (!uploadUrl || !downloadUrl) {
+    throw new Error('Gagal menyiapkan upload untuk Replicate.');
+  }
+  await axios.put(uploadUrl, buffer, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': buffer.length
+    },
+    maxBodyLength: Infinity,
+    maxContentLength: Infinity,
+    timeout: 60000
+  });
+  return downloadUrl;
+}
+
+async function runHairColorViaPythonCli(imageBase64, targetHex, strength = 1, options = {}) {
+  if (process.env.HAIR_COLOR_DISABLE_PYTHON_CLI === '1') {
+    throw new Error('Python hair color CLI disabled');
+  }
+
+  const cliPath = path.resolve(__dirname, '../magicmirror-python/cli_hair_color.py');
+  if (!fs.existsSync(cliPath)) {
+    throw new Error('Python hair color CLI tidak ditemukan');
+  }
+
+  const pythonBin = process.env.HAIR_COLOR_PYTHON_BIN || 'python3';
+  const args = [cliPath, '--hex', targetHex, '--strength', String(Math.max(0, Math.min(1, Number(strength) || 0)))];
+  const labelText = options && options.label;
+  if (labelText) {
+    args.push('--label', String(labelText));
+  }
+
+  const timeoutMs = Number(process.env.HAIR_COLOR_PYTHON_TIMEOUT_MS || 90000);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(pythonBin, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('Python hair color timeout'));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        const errText = stderr.trim() || stdout.trim() || `Python hair color exit code ${code}`;
+        return reject(new Error(errText));
+      }
+      try {
+        const parsed = JSON.parse(stdout || '{}');
+        if (!parsed || parsed.ok !== true || !parsed.imageOutBase64) {
+          const errMessage = parsed && parsed.error ? parsed.error : 'Python hair color response invalid';
+          return reject(new Error(errMessage));
+        }
+        const normalized = String(parsed.imageOutBase64).replace(/^data:image\/\w+;base64,/, '').replace(/[\r\n\s]+/g, '');
+        if (!normalized) {
+          return reject(new Error('Python hair color menghasilkan base64 kosong'));
+        }
+        resolve(normalized);
+      } catch (parseErr) {
+        const errMessage = parseErr && parseErr.message ? parseErr.message : 'Python hair color JSON parse error';
+        reject(new Error(errMessage));
+      }
+    });
+
+    try {
+      child.stdin.end(JSON.stringify({ imageBase64 }));
+    } catch (writeErr) {
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      reject(writeErr);
+    }
+  });
+}
+
+async function runHairColorViaReplicate(imageBase64, targetHex, strength = 1, options = {}) {
+  const replicateToken = process.env.REPLICATE_API_TOKEN || process.env.REPLICATE_API_KEY;
+  if (!replicateToken) {
+    throw new Error('REPLICATE_API_TOKEN belum dikonfigurasi');
+  }
+
+  const modelSlug = process.env.REPLICATE_HAIR_MODEL || 'minimax/image-01';
+  const modelVersion = process.env.REPLICATE_HAIR_VERSION || null;
+  const normalizedStrength = Math.max(0, Math.min(1, Number(strength) || 0));
+  const guidance = 7.2 + normalizedStrength * 3.8;
+  const steps = Math.max(28, Math.round(34 + normalizedStrength * 14));
+  const imageReference = await ensureReplicateReference(imageBase64, replicateToken);
+  const colorDescriptor = options && options.colorDescriptor ? options.colorDescriptor : `custom shade (${targetHex})`;
+  const prompt = [
+    `Edit this portrait. Focus exclusively on recoloring the person's hair to ${colorDescriptor}.`,
+    'Preserve every other element — identical face, skin tone, eyes, makeup, clothing, and background scene.',
+    'Maintain the existing hairstyle, lighting, hair texture, highlights, flyaways, and shadows.',
+    `Blend the new pigment realistically with an intensity level of ${(normalizedStrength).toFixed(2)} while keeping surroundings untouched.`
+  ].join(' ');
+
+  const inputPayload = {
+    prompt,
+    subject_prompt: 'same person, hair detail focus, ultra realistic portrait, crisp strands, background unchanged, professional lighting',
+    subject_reference: imageReference,
+    negative_prompt: 'different person, background color shift, clothing recolor, skin tone change, face alteration, makeup change, added text, watermark, artifacts',
+    guidance_scale: Number(guidance.toFixed(2)),
+    num_inference_steps: steps,
+    width: 1024,
+    height: 1024
+  };
+
+  const headers = {
+    Authorization: `Token ${replicateToken}`,
+    'Content-Type': 'application/json'
+  };
+
+  let prediction;
+  if (modelVersion) {
+    const { data } = await axios.post('https://api.replicate.com/v1/predictions', {
+      version: modelVersion,
+      input: inputPayload
+    }, { headers, timeout: 120000 });
+    prediction = data;
+  } else {
+    const { data } = await axios.post(`https://api.replicate.com/v1/models/${modelSlug}/predictions`, {
+      input: inputPayload
+    }, { headers, timeout: 120000 });
+    prediction = data;
+  }
+
+  const pollUrl = (prediction.urls && prediction.urls.get) || (prediction.id ? `https://api.replicate.com/v1/predictions/${prediction.id}` : null);
+
+  async function downloadOutput(outputList) {
+    if (!Array.isArray(outputList) || !outputList.length) {
+      throw new Error('Model tidak mengembalikan gambar.');
+    }
+    const lastUrl = outputList[outputList.length - 1];
+    const imgResp = await axios.get(lastUrl, { responseType: 'arraybuffer', timeout: 60000 });
+    return Buffer.from(imgResp.data).toString('base64');
+  }
+
+  if (prediction.status === 'succeeded') {
+    return downloadOutput(prediction.output);
+  }
+
+  if (!pollUrl) {
+    throw new Error('URL polling Replicate tidak tersedia.');
+  }
+
+  let attempts = 0;
+  const maxAttempts = 30; // ~60s polling (2s interval)
+  while (attempts < maxAttempts) {
+    await sleep(2000);
+    attempts += 1;
+    const { data: pollData } = await axios.get(pollUrl, { headers: { Authorization: `Token ${replicateToken}` }, timeout: 60000 });
+    if (pollData.status === 'succeeded') {
+      return downloadOutput(pollData.output);
+    }
+    if (pollData.status === 'failed' || pollData.status === 'canceled') {
+      const errDetail = pollData.error || `Replicate gagal dengan status ${pollData.status}`;
+      throw new Error(typeof errDetail === 'string' ? errDetail : JSON.stringify(errDetail));
+    }
+    if (pollData.error) {
+      throw new Error(typeof pollData.error === 'string' ? pollData.error : JSON.stringify(pollData.error));
+    }
+  }
+  throw new Error('Replicate timeout menunggu hasil hair color.');
+}
+
+const PRESET_COLOR_LABELS = {
+  '#8A7E72': 'Ash Brown',
+  '#E6A3A1': 'Rose Gold',
+  '#70193D': 'Burgundy',
+  '#2F8F9D': 'Blue Teal',
+  '#EAEAEA': 'Platinum',
+  '#4C2A85': 'Dark Violet'
+};
+
+function describeHairColor(hex, providedLabel) {
+  if (providedLabel) {
+    return `${providedLabel} (${hex})`;
+  }
+  const preset = PRESET_COLOR_LABELS[hex];
+  if (preset) return `${preset} (${hex})`;
+  try {
+    const intVal = parseInt(hex.replace('#', ''), 16);
+    if (Number.isNaN(intVal)) return `custom shade (${hex})`;
+    const r = (intVal >> 16) & 255;
+    const g = (intVal >> 8) & 255;
+    const b = intVal & 255;
+    const rn = r / 255;
+    const gn = g / 255;
+    const bn = b / 255;
+    const max = Math.max(rn, gn, bn);
+    const min = Math.min(rn, gn, bn);
+    const delta = max - min;
+    let hue = 0;
+    if (delta !== 0) {
+      if (max === rn) {
+        hue = ((gn - bn) / delta) % 6;
+      } else if (max === gn) {
+        hue = (bn - rn) / delta + 2;
+      } else {
+        hue = (rn - gn) / delta + 4;
+      }
+      hue *= 60;
+      if (hue < 0) hue += 360;
+    }
+    const lightness = (max + min) / 2;
+    const saturation = delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
+
+    let descriptor;
+    if (saturation < 0.12) {
+      descriptor = lightness > 0.7 ? 'soft platinum' : lightness < 0.3 ? 'deep charcoal' : 'neutral ash';
+    } else {
+      if (hue < 25) descriptor = lightness > 0.5 ? 'warm copper' : 'deep auburn';
+      else if (hue < 70) descriptor = lightness > 0.6 ? 'golden blonde' : 'honey brown';
+      else if (hue < 150) descriptor = lightness > 0.5 ? 'emerald teal' : 'deep moss green';
+      else if (hue < 210) descriptor = lightness > 0.5 ? 'cool azure' : 'midnight blue';
+      else if (hue < 280) descriptor = lightness > 0.5 ? 'violet amethyst' : 'deep indigo';
+      else descriptor = lightness > 0.5 ? 'rose quartz' : 'wine burgundy';
+    }
+    return `${descriptor} shade (${hex})`;
+  } catch (err) {
+    return `custom shade (${hex})`;
   }
 }
 

--- a/magicmirror-python/app.py
+++ b/magicmirror-python/app.py
@@ -1,6 +1,8 @@
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 import face_consultant_freshstart
+from hair_color import HairColorError, recolor as recolor_hair
+import logging
 import os
 
 app = Flask(__name__, static_folder='public')
@@ -20,6 +22,50 @@ def run_face_consultant():
         return jsonify(result)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/hair-color', methods=['POST'])
+def api_hair_color():
+    payload = request.get_json(silent=True) or {}
+    image_b64 = payload.get('imageBase64') or payload.get('image_base64') or payload.get('image')
+    hex_color = payload.get('hex') or payload.get('color')
+    strength = payload.get('strength', 0.7)
+    label = payload.get('label') or ''
+
+    try:
+        strength_val = float(strength)
+    except (TypeError, ValueError):
+        strength_val = 0.7
+
+    try:
+        result = recolor_hair(image_b64, hex_color, strength_val)
+    except HairColorError as err:
+        logging.warning(
+            'hair-color rejected request',
+            extra={'reason': str(err), 'label': label, 'hex': hex_color, 'strength': strength_val},
+        )
+        return jsonify({'ok': False, 'error': str(err)}), 400
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.exception('hair-color failed', extra={'label': label, 'hex': hex_color})
+        return jsonify({'ok': False, 'error': 'Hair color service error'}), 500
+
+    logging.info(
+        'hair-color success',
+        extra={
+            'label': label,
+            'hex': hex_color,
+            'strength': round(strength_val, 3),
+            'coverage': round(result.coverage, 4),
+            'mask_ratio': round(result.mask_ratio, 4),
+        },
+    )
+
+    return jsonify({
+        'ok': True,
+        'imageOutBase64': result.image_b64,
+        'coverage': result.coverage,
+        'maskRatio': result.mask_ratio,
+    })
 
 # ✅ Serve generated faces statically from backend folder
 @app.route('/generated_faces/<path:filename>')

--- a/magicmirror-python/cli_hair_color.py
+++ b/magicmirror-python/cli_hair_color.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""CLI bridge for invoking the hair recolor module from Node.
+
+Reads a JSON payload from stdin containing ``imageBase64`` and returns a
+JSON response with ``imageOutBase64`` so the Node server can reuse the same
+local algorithm even when the Flask service is unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from hair_color import HairColorError, recolor
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MagicMirror hair recolor CLI")
+    parser.add_argument("--hex", required=True, help="Target hair color in #RRGGBB")
+    parser.add_argument("--strength", type=float, default=0.7, help="Blend intensity (0-1)")
+    parser.add_argument("--label", default="", help="Optional label for logging context")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"Invalid JSON payload: {exc}\n")
+        return 2
+
+    image_b64 = None
+    if isinstance(payload, dict):
+        image_b64 = payload.get("imageBase64") or payload.get("image") or payload.get("image_base64")
+
+    try:
+        result = recolor(image_b64, args.hex, args.strength)
+    except HairColorError as err:
+        json.dump({"ok": False, "error": str(err)}, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"Unexpected error: {exc}\n")
+        return 3
+
+    json.dump({
+        "ok": True,
+        "imageOutBase64": result.image_b64,
+        "coverage": result.coverage,
+        "maskRatio": result.mask_ratio,
+        "label": args.label,
+    }, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magicmirror-python/hair_color.py
+++ b/magicmirror-python/hair_color.py
@@ -1,0 +1,223 @@
+"""Hair recoloring utilities with MediaPipe driven masking.
+
+This module builds a soft hair mask by combining selfie segmentation
+with the face oval landmarks so that skin, eyes, and background stay
+untouched. Colors are blended in CIELAB space which preserves existing
+lighting and texture for natural looking highlights and shadows.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import cv2
+import mediapipe as mp
+import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+
+# Pre-compute MediaPipe helpers once so the processors are reused across calls.
+_mp_selfie = mp.solutions.selfie_segmentation
+_mp_face_mesh = mp.solutions.face_mesh
+
+# Face oval sequence borrowed from MediaPipe reference indices (clockwise).
+_FACE_OVAL_SEQUENCE = [
+    10, 338, 297, 332, 284, 251, 389, 356,
+    454, 323, 361, 288, 397, 365, 379, 378,
+    400, 377, 152, 148, 176, 149, 150, 136,
+    172, 58, 132, 93, 234, 127, 162, 21,
+    54, 103, 67, 109
+]
+
+_PROCESS_LOCK = threading.Lock()
+_SEGMENTER = _mp_selfie.SelfieSegmentation(model_selection=1)
+_FACE_MESH = _mp_face_mesh.FaceMesh(
+    static_image_mode=True,
+    refine_landmarks=True,
+    max_num_faces=1,
+    min_detection_confidence=0.4,
+    min_tracking_confidence=0.4,
+)
+
+
+class HairColorError(Exception):
+    """Domain specific error for recoloring failures."""
+
+
+@dataclass
+class HairColorResult:
+    image_b64: str
+    coverage: float
+    mask_ratio: float
+
+
+def _decode_base64_image(data: str) -> np.ndarray:
+    if not data or not isinstance(data, str):
+        raise HairColorError("imageBase64 kosong")
+    payload = data.split(',', 1)[-1]
+    try:
+        img_bytes = base64.b64decode(payload, validate=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HairColorError(f"Gagal decode base64: {exc}") from exc
+    array = np.frombuffer(img_bytes, dtype=np.uint8)
+    image = cv2.imdecode(array, cv2.IMREAD_COLOR)
+    if image is None:
+        raise HairColorError("Gagal membaca gambar dari base64")
+    return image
+
+
+def _hex_to_bgr(hex_color: str) -> np.ndarray:
+    if not hex_color:
+        raise HairColorError("Warna target kosong")
+    value = hex_color.strip().lstrip('#')
+    if len(value) != 6:
+        raise HairColorError("Format warna harus #RRGGBB")
+    try:
+        r = int(value[0:2], 16)
+        g = int(value[2:4], 16)
+        b = int(value[4:6], 16)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HairColorError("Format warna tidak valid") from exc
+    return np.array([b, g, r], dtype=np.float32)
+
+
+def _landmark_points(landmarks, width: int, height: int) -> Optional[np.ndarray]:
+    if not landmarks:
+        return None
+    pts = []
+    for idx in _FACE_OVAL_SEQUENCE:
+        if idx >= len(landmarks.landmark):
+            continue
+        lm = landmarks.landmark[idx]
+        pts.append([int(lm.x * width), int(lm.y * height)])
+    if len(pts) < 3:
+        return None
+    return np.array(pts, dtype=np.int32)
+
+
+def _compute_face_masks(image_bgr: np.ndarray, rgb_image: np.ndarray):
+    height, width = image_bgr.shape[:2]
+    person_mask = None
+    face_polygon = None
+
+    with _PROCESS_LOCK:
+        seg_result = _SEGMENTER.process(rgb_image)
+        mesh_result = _FACE_MESH.process(rgb_image)
+
+    if seg_result.segmentation_mask is None:
+        raise HairColorError("Segmentation mask kosong")
+
+    # Convert segmentation probability map into a soft mask for the subject.
+    person_mask = np.clip(seg_result.segmentation_mask, 0.0, 1.0)
+    person_mask = cv2.GaussianBlur(person_mask, (9, 9), 0)
+    person_mask = (person_mask > 0.25).astype(np.uint8) * 255
+
+    if mesh_result.multi_face_landmarks:
+        face_polygon = _landmark_points(mesh_result.multi_face_landmarks[0], width, height)
+
+    return person_mask, face_polygon
+
+
+def _build_hair_mask(person_mask: np.ndarray, face_polygon: Optional[np.ndarray], shape: Tuple[int, int]) -> np.ndarray:
+    height, width = shape
+    mask = np.zeros((height, width), dtype=np.uint8)
+
+    if person_mask is None or not np.any(person_mask):
+        return mask
+
+    if face_polygon is None:
+        # Fall back to a centered crop of the person mask.
+        margin_x = int(width * 0.35)
+        margin_y = int(height * 0.25)
+        x0, x1 = margin_x, width - margin_x
+        y0, y1 = max(0, margin_y // 2), min(height, height - margin_y // 3)
+        mask[y0:y1, x0:x1] = person_mask[y0:y1, x0:x1]
+    else:
+        face_mask = np.zeros_like(mask)
+        cv2.fillPoly(face_mask, [face_polygon], 255)
+        dilated_face = cv2.dilate(face_mask, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (35, 35)), iterations=1)
+        dilated_face = cv2.GaussianBlur(dilated_face, (31, 31), 0)
+
+        x_min = np.clip(int(np.min(face_polygon[:, 0]) - (np.ptp(face_polygon[:, 0]) * 0.6)), 0, width)
+        x_max = np.clip(int(np.max(face_polygon[:, 0]) + (np.ptp(face_polygon[:, 0]) * 0.6)), 0, width)
+        y_min = np.clip(int(np.min(face_polygon[:, 1]) - (np.ptp(face_polygon[:, 1]) * 0.9)), 0, height)
+        y_max = np.clip(int(np.max(face_polygon[:, 1]) + (np.ptp(face_polygon[:, 1]) * 1.3)), 0, height)
+
+        cropped = np.zeros_like(mask)
+        cropped[y_min:y_max, x_min:x_max] = person_mask[y_min:y_max, x_min:x_max]
+        mask = cv2.bitwise_and(cropped, cv2.bitwise_not(dilated_face))
+
+    if not np.any(mask):
+        return mask
+
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (17, 17))
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+    mask = cv2.GaussianBlur(mask, (25, 25), 0)
+    return mask
+
+
+def _apply_color(image_bgr: np.ndarray, hair_mask: np.ndarray, target_bgr: np.ndarray, strength: float) -> Tuple[np.ndarray, float, float]:
+    normalized_strength = float(np.clip(strength, 0.0, 1.0))
+    if normalized_strength <= 0.01:
+        return image_bgr.copy(), 0.0, 0.0
+
+    mask = hair_mask.astype(np.float32) / 255.0
+    if mask.max() <= 0.01:
+        raise HairColorError("Mask rambut tidak ditemukan")
+
+    mask *= normalized_strength
+    mask = np.clip(mask, 0.0, 1.0)
+
+    lab_image = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2LAB).astype(np.float32)
+    target_lab = cv2.cvtColor(target_bgr.reshape(1, 1, 3).astype(np.uint8), cv2.COLOR_BGR2LAB).astype(np.float32)[0, 0]
+
+    mask_3 = mask[..., None]
+    a_channel = lab_image[:, :, 1]
+    b_channel = lab_image[:, :, 2]
+    lab_image[:, :, 1] = a_channel + (target_lab[1] - a_channel) * mask_3
+    lab_image[:, :, 2] = b_channel + (target_lab[2] - b_channel) * mask_3
+
+    # Preserve natural lighting by slightly nudging luminance toward the target.
+    lab_image[:, :, 0] = lab_image[:, :, 0] + (target_lab[0] - lab_image[:, :, 0]) * (mask_3 * 0.12)
+
+    recolored = cv2.cvtColor(np.clip(lab_image, 0, 255).astype(np.uint8), cv2.COLOR_LAB2BGR)
+    blended = (recolored.astype(np.float32) * mask_3) + (image_bgr.astype(np.float32) * (1.0 - mask_3))
+    blended = np.clip(blended, 0, 255).astype(np.uint8)
+
+    coverage = float(np.mean(mask))
+    mask_ratio = float((hair_mask > 16).sum() / float(hair_mask.size))
+    return blended, coverage, mask_ratio
+
+
+def recolor(image_base64: str, hex_color: str, strength: float) -> HairColorResult:
+    image_bgr = _decode_base64_image(image_base64)
+    target_bgr = _hex_to_bgr(hex_color)
+    rgb_image = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+
+    person_mask, face_polygon = _compute_face_masks(image_bgr, rgb_image)
+    hair_mask = _build_hair_mask(person_mask, face_polygon, image_bgr.shape[:2])
+
+    recolored_bgr, coverage, mask_ratio = _apply_color(image_bgr, hair_mask, target_bgr, strength)
+
+    success, buffer = cv2.imencode('.jpg', recolored_bgr, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+    if not success:
+        raise HairColorError("Gagal menyimpan hasil hair color")
+    image_b64 = base64.b64encode(buffer).decode('ascii')
+
+    LOGGER.info(
+        "hair_color.recolor completed",
+        extra={
+            'coverage': round(coverage, 4),
+            'mask_ratio': round(mask_ratio, 4),
+            'strength': float(strength),
+        },
+    )
+
+    return HairColorResult(image_b64=image_b64, coverage=coverage, mask_ratio=mask_ratio)
+
+
+__all__ = ['HairColorError', 'HairColorResult', 'recolor']


### PR DESCRIPTION
## Summary
- attach color labels from the hair panel swatches and custom picker so recolor requests include descriptive context for prompts
- add a MediaPipe-driven `/api/hair-color` delegate in the Python service and make the Node API prefer that endpoint while retaining Replicate as a fallback with clearer error reporting
- keep the hair panel UI responsive by disabling controls during processing while restoring status messaging after completion
- refine the Replicate fallback prompt so it explicitly targets hair strands while leaving the background untouched
- add a Python CLI fallback so the Node endpoint can always run the local MediaPipe recolor even if the delegate service is unreachable

## Testing
- python -m compileall magicmirror-python/cli_hair_color.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb13a869c83259ade7d53899e4269