### PR TITLE
Improve voice command stability and add open/start triggers

### DIFF
--- a/magicmirror-node/public/mmfront.html
+++ b/magicmirror-node/public/mmfront.html
@@ -1146,11 +1146,13 @@ h1{
   let rec = null;
   let listening = false;
   let armed = false; // after hotword
+  let lastHotwordAt = 0;
+  let processedSegments = new Map();
 
   function setArmed(on){
     armed = !!on;
     document.body.classList.toggle('vc-armed', armed);
-    if(armed){ vcToast('🎤 Listening… ucapkan "mulai analisa"', 1600); }
+    if(armed){ vcToast('🎤 Listening… ucapkan "open" atau "mulai analisa"', 1600); }
   }
 
   function ensureRec(){
@@ -1160,73 +1162,87 @@ h1{
     rec.continuous = true; // keep running
     rec.interimResults = true;
 
+    rec.onstart = ()=>{ processedSegments = new Map(); };
     rec.onresult = (e)=>{
-      let finalTxt = '';
-      for(let i=0;i<e.results.length;i++){
+      for(let i = e.resultIndex || 0; i < e.results.length; i++){
         const r = e.results[i];
-        const txt = r[0] && r[0].transcript ? r[0].transcript.toLowerCase() : '';
+        let txt = r[0] && r[0].transcript ? r[0].transcript.toLowerCase() : '';
+        txt = txt.trim();
         if(!txt) continue;
+        if(processedSegments.get(i) === txt){ continue; }
+        processedSegments.set(i, txt);
+        if(processedSegments.size > 32){
+          const keys = Array.from(processedSegments.keys());
+          while(keys.length && processedSegments.size > 16){ processedSegments.delete(keys.shift()); }
+        }
+        const simpleTxt = txt.replace(/[.,!?]/g,' ').replace(/\s+/g,' ').trim();
         // Hotword: "hey mirror" / "hei miror" / common variants
-        if(/\b(hey|hei|hai)\s+mir+r?or\b/.test(txt)){
+        if(/\b(hey|hei|hai)\s+mir+r?or\b/.test(simpleTxt)){
+          const now = Date.now();
+          if(now - lastHotwordAt < 1200){ continue; }
+          lastHotwordAt = now;
           // Turn camera ON immediately as requested
           if(!document.body.classList.contains('camera-on')){ camBtn?.click(); }
           setArmed(true);
-          vcToast('✅ Hey Mirror — kamera siap. Ucap: "mulai analisa"', 1800);
+          vcToast('✅ Hey Mirror — kamera siap. Ucap: "open" atau "mulai analisa"', 1800);
           try {
-            window.ttsSpeak && window.ttsSpeak("Hello, I am ready. Please say analyze to begin.", { rate:0.97, pitch:1.08 });
+            window.ttsSpeak && window.ttsSpeak("Hello, I am ready. Say open to turn on the camera or say analyze to begin.", { rate:0.97, pitch:1.08 });
           } catch(_) {}
           try{ window.showAppSuggest && window.showAppSuggest(); }catch(_){ }
           continue;
         }
         // Command: matikan kamera / stop (turn off live cam)
-        if (/\b(matikan\s+kamera|stop)\b/.test(txt)) {
+        if (/\b(matikan\s+kamera|stop)\b/.test(simpleTxt)) {
           if (document.body.classList.contains('camera-on')) {
             if (typeof stopCamera === 'function') stopCamera();
             vcToast('📷 Kamera dimatikan.', 1200);
           }
           continue;
         }
-        // Command: hidupkan kamera / start (turn on live cam)
-        if (/\b(hidupkan\s+kamera|start)\b/.test(txt)) {
+        // Command: hidupkan kamera / open (turn on live cam)
+        const soloOpen = simpleTxt === 'open';
+        const soloStart = simpleTxt === 'start';
+        if (soloOpen || /\b(hidupkan\s+kamera|buka\s+kamera|open\s+(camera|kamera))\b/.test(simpleTxt)) {
           if (!document.body.classList.contains('camera-on')) {
             if (typeof startCamera === 'function') startCamera();
+            else { camBtn?.click(); }
             vcToast('📷 Kamera dinyalakan.', 1200);
           }
           continue;
         }
         // Command: fullscreen
-        if (/\bfullscreen\b/.test(txt)) {
+        if (/\bfullscreen\b/.test(simpleTxt)) {
           (fsBtn || document.getElementById('fullscreen'))?.click();
           vcToast('⛶ Fullscreen toggle', 1000);
           continue;
         }
         // Command: buka/nonton/open/watch Netflix
-        if (armed && (/(buka|nonton|tonton|open|watch)\s+netflix\b/.test(txt) || /\bnetflix\b/.test(txt))) {
+        if (armed && (/(buka|nonton|tonton|open|watch)\s+netflix\b/.test(simpleTxt) || /\bnetflix\b/.test(simpleTxt))) {
           try{ window.openApp && window.openApp('netflix'); }catch(_){ }
           setArmed(false);
           continue;
         }
 
         // Command: buka/dengarkan/putar/open/listen/play Spotify
-        if (armed && (/(buka|dengarkan|dengerin|putar|mainkan|open|listen|play)\s+spotify\b/.test(txt) || /\bspotify\b/.test(txt))) {
+        if (armed && (/(buka|dengarkan|dengerin|putar|mainkan|open|listen|play)\s+spotify\b/.test(simpleTxt) || /\bspotify\b/.test(simpleTxt))) {
           try{ window.openApp && window.openApp('spotify'); }catch(_){ }
           setArmed(false);
           continue;
         }
         // Command: matikan mic (stop voice recognition)
-        if (/\b(matik(?:an)?\s+(mic|mikrofon)|mute(?:\s+mic)?|nonaktifkan\s+mic)\b/.test(txt)) {
+        if (/\b(matik(?:an)?\s+(mic|mikrofon)|mute(?:\s+mic)?|nonaktifkan\s+mic)\b/.test(simpleTxt)) {
           stop();
           vcToast('🎙️ Mic dimatikan.', 1200);
           continue;
         }
         // Command: hidupkan mic (start/restart voice recognition)
-        if (/\b(hidup(?:kan)?\s+(mic|mikrofon)|aktifkan\s+mic|unmute(?:\s+mic)?)\b/.test(txt)) {
+        if (/\b(hidup(?:kan)?\s+(mic|mikrofon)|aktifkan\s+mic|unmute(?:\s+mic)?)\b/.test(simpleTxt)) {
           start();
           vcToast('🎙️ Mic dinyalakan.', 1200);
           continue;
         }
         // Command: mulai analisa / analyze
-        if(armed && (/mulai\s+analisa/.test(txt) || /analy[sz]e/.test(txt))){
+        if((armed && (/mulai\s+analisa/.test(simpleTxt) || /analy[sz]e/.test(simpleTxt) || /\banalisa\b/.test(simpleTxt) || soloStart)) || (!armed && /\bmulai\s+analisa\b/.test(simpleTxt))){
           // Ensure camera on & click Analyze (even if disabled)
           const doClick = ()=>{
             if(window.__pageBusy){ vcToast('⏳ Masih memproses…', 900); return; }
@@ -1262,6 +1278,7 @@ h1{
     if(listening) return;
     try{
       ensureRec();
+      processedSegments = new Map();
       rec.start();
       try{ localStorage.setItem('vcAuto','1'); }catch(_){ }
       listening = true;
@@ -1279,6 +1296,7 @@ h1{
     listening = false;
     setArmed(false);
     try{ rec && rec.stop(); }catch(_){}
+    processedSegments = new Map();
     vcBtn.setAttribute('aria-pressed','false');
     vcBtn.classList.remove('listening');
     toastEl.classList.remove('show');


### PR DESCRIPTION
## Summary
- debounce repeated recognition segments so the "Hey Mirror" greeting plays smoothly
- allow the single-word "open" command to power on the camera while keeping the session armed
- accept "start" and "analisa" as analyze triggers and refresh mic prompts to mention the new commands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfea4d17d08325b83a7f2a12abc506