### PR TITLE
Add contextual redirect after sign up

### DIFF
--- a/magicmirror-node/public/elearn/daftar.html
+++ b/magicmirror-node/public/elearn/daftar.html
@@ -411,6 +411,32 @@
     });
     document.getElementById('togglePass').addEventListener('click', ()=>{ const t = pass.getAttribute('type')==='password'?'text':'password'; pass.setAttribute('type', t); });
 
+    const params = new URLSearchParams(window.location.search);
+    const DEFAULT_REDIRECT = '/elearn/login.html';
+    function sanitizeRedirect(target){
+      if (!target) return null;
+      try {
+        const url = new URL(target, window.location.origin);
+        if (url.origin !== window.location.origin) return null;
+        if (url.pathname === window.location.pathname) return null;
+        return `${url.pathname}${url.search || ''}${url.hash || ''}`;
+      } catch (_){
+        return null;
+      }
+    }
+    let redirectPath = sanitizeRedirect(params.get('next'));
+    if (!redirectPath && document.referrer){
+      try {
+        const refUrl = new URL(document.referrer);
+        if (refUrl.origin === window.location.origin && refUrl.pathname !== window.location.pathname){
+          redirectPath = `${refUrl.pathname}${refUrl.search || ''}${refUrl.hash || ''}`;
+        }
+      } catch (_){ /* ignore */ }
+    }
+    redirectPath = redirectPath || DEFAULT_REDIRECT;
+    const signInLink = document.querySelector('.muted .link');
+    if (signInLink){ signInLink.setAttribute('href', redirectPath); }
+
     const statusEl = document.getElementById('status');
     const form = document.getElementById('signupForm');
     const btn = document.getElementById('submitBtn');
@@ -495,7 +521,7 @@
         try{ localStorage.setItem('USER_INFO', JSON.stringify({ uid, cid, nama, email, wa, role:'murid' })); }catch(_){ }
         await registerBackend({ uid, cid, nama, email, wa, password: pwd, role: 'murid' });
         setStatus('✅ Account created. Redirecting to sign in…', true);
-        setTimeout(()=>{ window.location.href = '/elearn/login.html'; }, 1200);
+        setTimeout(()=>{ window.location.href = redirectPath; }, 1200);
       }catch(err){
         console.error(err);
         setStatus('❌ Sign up failed: ' + (err && err.message ? err.message : 'Unknown error'), false);

--- a/magicmirror-node/public/elearn/login.html
+++ b/magicmirror-node/public/elearn/login.html
@@ -649,7 +649,7 @@
             <!-- Login & Daftar Buttons -->
             <div class="button-row">
               <button onclick="login()" id="login-btn" class="login-button">Login</button>
-              <button onclick="window.location.href='/elearn/daftar.html'" class="daftar-akun">Sign Up</button>
+              <button onclick="goToSignup()" class="daftar-akun">Sign Up</button>
             </div>
 
 
@@ -783,6 +783,12 @@ async function login() {
       }
     });
   });
+}
+
+function goToSignup() {
+  const { pathname, search, hash } = window.location;
+  const nextTarget = encodeURIComponent(`${pathname}${search || ''}${hash || ''}`);
+  window.location.href = `/elearn/daftar.html?next=${nextTarget}`;
 }
 
 <!-- (removed duplicate script end tag) -->

--- a/magicmirror-node/public/login.html
+++ b/magicmirror-node/public/login.html
@@ -177,7 +177,7 @@
       </form>
       <p id="status" style="color:red; font-size:0.85rem; margin-top:0.5rem;"></p>
       <p style="font-size:0.85rem; margin-top:1rem; color:#4b4b4b;">Belum punya akun?</p>
-      <button style="background:#e6f4ff; color:#007acc; border:none; padding:0.4rem 0.8rem; border-radius:10px; font-size:0.8rem;">Buat akun</button>
+      <button onclick="goToSignup()" style="background:#e6f4ff; color:#007acc; border:none; padding:0.4rem 0.8rem; border-radius:10px; font-size:0.8rem;">Buat akun</button>
     </div>
   </div>
 
@@ -367,6 +367,13 @@
     const passwordInput = document.getElementById("password");
     const type = passwordInput.getAttribute("type") === "password" ? "text" : "password";
     passwordInput.setAttribute("type", type);
+  }
+</script>
+<script>
+  function goToSignup() {
+    const { pathname, search, hash } = window.location;
+    const nextTarget = encodeURIComponent(`${pathname}${search || ''}${hash || ''}`);
+    window.location.href = `/elearn/daftar.html?next=${nextTarget}`;
   }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- include a contextual `next` parameter when navigating to the sign up page from either login entry point
- sanitize the requested return location on sign up, update the "Sign in" link, and redirect back to the originating login page after registration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e36f0cad648325bc16950d07d07a2d