### PR TITLE
Polish start modal login iframe styling

### DIFF
--- a/magicmirror-node/public/start.html
+++ b/magicmirror-node/public/start.html
@@ -766,24 +766,33 @@
 
       .inline-login__frame {
         position: relative;
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
         width: 100%;
-        max-width: 420px;             /* biar proporsional di mobile */
-        /* Lebih pendek secara default, dan tidak memaksa fullscreen */
-        min-height: min(360px, 50vh);
-        max-height: 72dvh;            /* cap supaya frame putih tidak kepanjangan */
-        border-radius: 22px;
+        max-width: none;
+        min-height: min(400px, 55vh);
+        max-height: 72dvh;
+        border-radius: 24px;
         overflow: hidden;
         border: 1px solid rgba(255, 255, 255, 0.18);
-        background: rgba(6, 6, 22, 0.78);
-        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+        background:
+          radial-gradient(circle at 20% 15%, rgba(255, 63, 245, 0.16), transparent 60%),
+          radial-gradient(circle at 80% 85%, rgba(24, 241, 255, 0.14), transparent 55%),
+          rgba(9, 11, 34, 0.9);
+        box-shadow:
+          0 24px 60px rgba(5, 10, 38, 0.5),
+          inset 0 0 0 1px rgba(255, 255, 255, 0.05);
       }
 
       .inline-login__frame iframe {
         display: block;
+        flex: 1 1 auto;
         width: 100%;
         height: 100%;
         border: 0;
-        background: transparent;
+        background: rgba(9, 11, 34, 0.98);
+        color-scheme: dark;
       }
 
       @media (max-width: 640px) {
@@ -1252,7 +1261,13 @@
               </div>
               <div class="inline-login__frame">
                 <!-- lazy load the iframe when selected -->
-                <iframe title="Login" data-src="/elearn/login.html?embed=1" loading="lazy" referrerpolicy="no-referrer"></iframe>
+                <iframe
+                  title="Login"
+                  data-src="/elearn/login.html?embed=1"
+                  loading="lazy"
+                  referrerpolicy="no-referrer"
+                  allowtransparency="true"
+                ></iframe>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- stretch the inline login iframe wrapper to fill the start modal card
- refresh the wrapper background and iframe defaults so the embed blends with the dark theme
- allow transparent rendering to avoid white flashes while the iframe content loads

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5ebf511308325a8bb6775671a136b