### PR TITLE
Fix login embed layering and restore standalone slides

### DIFF
--- a/magicmirror-node/public/elearn/login.html
+++ b/magicmirror-node/public/elearn/login.html
@@ -29,11 +29,36 @@
   </script>
   <script>
     const urlParams = new URLSearchParams(window.location.search);
-    const isEmbedMode = urlParams.get('embed') === '1' || urlParams.get('embed') === 'true';
+    const embedParam = urlParams.get('embed');
+    let isEmbedMode = embedParam === '1' || embedParam === 'true';
     const embedRedirectTarget = urlParams.get('redirect') || '';
+
+    const activateLoginEmbedShell = () => {
+      if (!document.documentElement.classList.contains('login-embed')) {
+        document.documentElement.classList.add('login-embed');
+      }
+      window.__EMBED__ = true;
+    };
+
     if (isEmbedMode) {
-      document.documentElement.classList.add('login-embed');
+      activateLoginEmbedShell();
     }
+
+    window.addEventListener('message', (event) => {
+      if (event && event.data && event.data.type === 'enableEmbedMode') {
+        if (!isEmbedMode) {
+          isEmbedMode = true;
+        }
+        activateLoginEmbedShell();
+        if (document.readyState !== 'loading' && typeof window.__applyLoginEmbed === 'function') {
+          try {
+            window.__applyLoginEmbed(true);
+          } catch (error) {
+            console.warn('Gagal menerapkan mode embed login setelah pesan:', error);
+          }
+        }
+      }
+    });
   </script>
   <style>
     .cta-digital-experience {
@@ -80,7 +105,8 @@
       border: 0;
     }
 
-    body.login-body {
+    html.login-embed body.login-body,
+    html.is-embed body.login-body {
       margin: 0;
       font-family: 'Inter', 'Segoe UI', sans-serif;
       background: linear-gradient(180deg, #e0f7ff, #f0fbff);
@@ -129,7 +155,7 @@
       overflow-y: visible;
     }
 
-    html.login-embed.in-start-modal body.login-body {
+    html.login-embed.in-start-modal body {
       justify-content: flex-start;
       align-items: center;
       padding: clamp(1.5rem, 4vw, 2.5rem) 0;
@@ -172,6 +198,10 @@
       max-height: 76dvh;           /* lebih pendek supaya pas */
       overflow: auto;
       padding: clamp(1.6rem, 4vw, 2.6rem);
+      background: transparent !important;
+      border: 0 !important;
+      box-shadow: none !important;
+      backdrop-filter: none !important;
     }
 
     .login-card__header {
@@ -474,16 +504,20 @@
       .cta-digital-experience { z-index: 1 !important; }
     }
     /* Embed specific styling */
-    html.login-embed, html.login-embed body {
-      overflow: hidden;
-    }
-
-    html.login-embed body.login-body {
+    html.login-embed,
+    html.login-embed body {
       font-family: 'Rajdhani', 'Inter', sans-serif;
       background: transparent;
       min-height: auto;
       padding: 0;
       text-align: left;
+      overflow: hidden;
+      color: #f3f6ff;
+      color-scheme: dark;
+    }
+
+    html.login-embed body::before {
+      content: none !important;
     }
 
     html.login-embed .login-container {
@@ -1040,23 +1074,52 @@
 </style>
   <script id="embed-mode-boot">
     (function () {
-      try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const inIframe = (function(){ try { return window.self !== window.top; } catch { return true; } })();
-        if (urlParams.get('embed') === '1' || inIframe) {
-          document.documentElement.classList.add('is-embed');
-          document.body.classList.add('is-embed');
-          window.__EMBED__ = true;
+      const params = new URLSearchParams(window.location.search);
+      let embedApplied = false;
+
+      const ensureBodyEmbedClass = () => {
+        if (!document.body) {
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              document.body.classList.add('is-embed');
+            },
+            { once: true }
+          );
+          return;
         }
-        // allow parent to force embed after load
-        window.addEventListener('message', (e) => {
-          if (e && e.data && e.data.type === 'enableEmbedMode') {
-            document.documentElement.classList.add('is-embed');
-            document.body.classList.add('is-embed');
-            window.__EMBED__ = true;
+        document.body.classList.add('is-embed');
+      };
+
+      const enableEmbedMode = () => {
+        if (embedApplied) {
+          return;
+        }
+        embedApplied = true;
+        document.documentElement.classList.add('is-embed');
+        ensureBodyEmbedClass();
+        if (typeof isEmbedMode !== 'undefined') {
+          isEmbedMode = true;
+        }
+        window.__EMBED__ = true;
+        if (document.readyState !== 'loading' && typeof window.__applyLoginEmbed === 'function') {
+          try {
+            window.__applyLoginEmbed(true);
+          } catch (error) {
+            console.warn('Gagal menerapkan tata letak embed login:', error);
           }
-        });
-      } catch {}
+        }
+      };
+
+      if (params.get('embed') === '1' || params.get('embed') === 'true') {
+        enableEmbedMode();
+      }
+
+      window.addEventListener('message', (event) => {
+        if (event && event.data && event.data.type === 'enableEmbedMode') {
+          enableEmbedMode();
+        }
+      });
     })();
   </script>
   <style id="embed-mode-css">
@@ -1343,6 +1406,26 @@
     }
   }
 
+  function applyLoginEmbed(initialForce = false) {
+    if (!isEmbedMode) {
+      return;
+    }
+    if (document.body && !document.body.classList.contains('login-body')) {
+      document.body.classList.add('login-body');
+    }
+    const embedWrapper = document.querySelector('[data-embed-login]');
+    if (embedWrapper && embedWrapper.hasAttribute('aria-hidden')) {
+      embedWrapper.removeAttribute('aria-hidden');
+    }
+    notifyParentAboutSize(initialForce);
+    setTimeout(() => notifyParentAboutSize(), 120);
+    setupEmbedResizeObserver();
+  }
+
+  window.__applyLoginEmbed = (initialForce = false) => {
+    applyLoginEmbed(initialForce);
+  };
+
   function setEmbedStatus(message, type = 'info') {
     const statusEl = document.getElementById('embedStatus');
     if (statusEl) {
@@ -1584,14 +1667,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     if (isEmbedMode) {
-      document.body.classList.add('login-body');
-      const embedWrapper = document.querySelector('[data-embed-login]');
-      if (embedWrapper) {
-        embedWrapper.removeAttribute('aria-hidden');
-      }
-      notifyParentAboutSize(true);
-      setTimeout(() => notifyParentAboutSize(), 120);
-      setupEmbedResizeObserver();
+      applyLoginEmbed(true);
     }
 
     const loginForm = document.getElementById('embedLoginForm');

--- a/magicmirror-node/public/start.html
+++ b/magicmirror-node/public/start.html
@@ -766,24 +766,34 @@
 
       .inline-login__frame {
         position: relative;
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
         width: 100%;
-        max-width: 420px;             /* biar proporsional di mobile */
-        /* Lebih pendek secara default, dan tidak memaksa fullscreen */
-        min-height: min(360px, 50vh);
-        max-height: 72dvh;            /* cap supaya frame putih tidak kepanjangan */
-        border-radius: 22px;
+        max-width: none;
+        min-height: min(400px, 55vh);
+        max-height: 72dvh;
+        border-radius: 24px;
         overflow: hidden;
         border: 1px solid rgba(255, 255, 255, 0.18);
-        background: rgba(6, 6, 22, 0.78);
-        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+        background:
+          radial-gradient(circle at 20% 15%, rgba(255, 63, 245, 0.16), transparent 60%),
+          radial-gradient(circle at 80% 85%, rgba(24, 241, 255, 0.14), transparent 55%),
+          rgba(9, 11, 34, 0.9);
+        box-shadow:
+          0 24px 60px rgba(5, 10, 38, 0.5),
+          inset 0 0 0 1px rgba(255, 255, 255, 0.05);
       }
 
       .inline-login__frame iframe {
         display: block;
+        flex: 1 1 auto;
         width: 100%;
         height: 100%;
         border: 0;
         background: transparent;
+        background-color: transparent;
+        color-scheme: dark;
       }
 
       @media (max-width: 640px) {
@@ -1252,7 +1262,13 @@
               </div>
               <div class="inline-login__frame">
                 <!-- lazy load the iframe when selected -->
-                <iframe title="Login" data-src="/elearn/login.html?embed=1" loading="lazy" referrerpolicy="no-referrer"></iframe>
+                <iframe
+                  title="Login"
+                  data-src="/elearn/login.html?embed=1"
+                  loading="lazy"
+                  referrerpolicy="no-referrer"
+                  allowtransparency="true"
+                ></iframe>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- require the explicit embed flag or message before activating the login iframe mode and centralize the layout application logic so standalone login keeps its side slides
- expose an embed helper that parent pages can reuse after load while keeping the start modal view visually seamless by removing the inner card background from the iframe content and clearing the iframe fallback background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ebf511308325a8bb6775671a136b