### PR TITLE
Send Calistung worksheets to WhatsApp

### DIFF
--- a/magicmirror-node/public/elearn/userInfo.js
+++ b/magicmirror-node/public/elearn/userInfo.js
@@ -4,6 +4,13 @@ function getUserInfo() {
     role: localStorage.getItem("role"),
     nama: localStorage.getItem("nama"),
     uid: localStorage.getItem("uid"),
-    cid: localStorage.getItem("cid")
+    cid: localStorage.getItem("cid"),
+    whatsapp: (function(){
+      try {
+        return localStorage.getItem("whatsapp") || localStorage.getItem("qa_whatsapp") || sessionStorage.getItem("whatsapp") || '';
+      } catch (_){
+        return '';
+      }
+    })()
   };
 }

--- a/magicmirror-node/public/elearn/worlds/calistung/alphabet/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/alphabet/index.html
@@ -48,5 +48,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/index.html
@@ -82,5 +82,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/index.html
@@ -48,5 +48,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/shape/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/shape/index.html
@@ -58,5 +58,6 @@
       try { const p = document.getElementById('hudPanel'); if (p) p.classList.remove('open'); } catch(_){ }
     }, 0);
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Calistung WhatsApp helper that enforces number capture, stores it, and sends worksheet results to the configured number
- expose stored WhatsApp numbers via getUserInfo and ensure Calistung world entry points load the helper script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62000ed848325bc5e8cfb823336b3