### PR TITLE
Send Calistung worksheets to WhatsApp and align world navigation

### DIFF
--- a/magicmirror-node/public/elearn/common/calistung-navbar.js
+++ b/magicmirror-node/public/elearn/common/calistung-navbar.js
@@ -855,16 +855,27 @@
     const body = document.body;
     const dataset = body.dataset;
     const classList = body.classList;
+    const portalUrl = '/elearn/worlds/portal.html';
+
+    const pathname = (typeof window !== 'undefined' && window.location && window.location.pathname)
+      ? window.location.pathname.toLowerCase()
+      : '';
 
     const badgeValue = (dataset.navBadge || '').toLowerCase();
     let isShapeWorld = false;
     let isMathWorld = false;
+    let isAlphabetWorld = false;
+    let isNumberWorld = false;
 
     if (classList && typeof classList.contains === 'function') {
       if (classList.contains('shape-shell')) {
         isShapeWorld = true;
       } else if (classList.contains('mathgame-shell')) {
         isMathWorld = true;
+      } else if (classList.contains('alphabet-game')) {
+        isAlphabetWorld = true;
+      } else if (classList.contains('number-game')) {
+        isNumberWorld = true;
       }
     }
 
@@ -874,8 +885,23 @@
           isShapeWorld = true;
         } else if (badgeValue.indexOf('math') !== -1 || badgeValue.indexOf('angka') !== -1) {
           isMathWorld = true;
+        } else if (badgeValue.indexOf('alphabet') !== -1 || badgeValue.indexOf('huruf') !== -1) {
+          isAlphabetWorld = true;
+        } else if (badgeValue.indexOf('number') !== -1) {
+          isNumberWorld = true;
         }
       }
+    }
+
+    if (!isAlphabetWorld && pathname.indexOf('/calistung/alphabet/') !== -1) {
+      isAlphabetWorld = true;
+    }
+    if (!isNumberWorld && pathname.indexOf('/calistung/number/') !== -1) {
+      isNumberWorld = true;
+    }
+
+    if (!dataset.navBackUrl) {
+      dataset.navBackUrl = portalUrl;
     }
 
     if (isShapeWorld) {
@@ -908,6 +934,28 @@
       }
       if (!dataset.pauseToggle) {
         dataset.pauseToggle = 'disabled';
+      }
+    }
+
+    if (isAlphabetWorld) {
+      if (!dataset.navBadge) {
+        dataset.navBadge = 'Calistung Alphabet';
+      }
+      dataset.navHomeUrl = '/elearn/worlds/calistung/alphabet/index.html';
+      dataset.navBackUrl = portalUrl;
+      if ((dataset.navBackBehavior || '').toLowerCase() === 'pause-menu') {
+        dataset.navBackBehavior = 'link';
+      }
+    }
+
+    if (isNumberWorld) {
+      if (!dataset.navBadge) {
+        dataset.navBadge = 'Calistung Number';
+      }
+      dataset.navHomeUrl = '/elearn/worlds/calistung/number/index.html';
+      dataset.navBackUrl = portalUrl;
+      if ((dataset.navBackBehavior || '').toLowerCase() === 'pause-menu') {
+        dataset.navBackBehavior = 'link';
       }
     }
 

--- a/magicmirror-node/public/elearn/userInfo.js
+++ b/magicmirror-node/public/elearn/userInfo.js
@@ -4,6 +4,13 @@ function getUserInfo() {
     role: localStorage.getItem("role"),
     nama: localStorage.getItem("nama"),
     uid: localStorage.getItem("uid"),
-    cid: localStorage.getItem("cid")
+    cid: localStorage.getItem("cid"),
+    whatsapp: (function(){
+      try {
+        return localStorage.getItem("whatsapp") || localStorage.getItem("qa_whatsapp") || sessionStorage.getItem("whatsapp") || '';
+      } catch (_){
+        return '';
+      }
+    })()
   };
 }

--- a/magicmirror-node/public/elearn/worlds/calistung/alphabet/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/alphabet/index.html
@@ -48,5 +48,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/index.html
@@ -82,5 +82,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/math-game/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/math-game/index.html
@@ -48,5 +48,6 @@
       window.CalistungMusic.ensureTheme();
     }
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>

--- a/magicmirror-node/public/elearn/worlds/calistung/shape/index.html
+++ b/magicmirror-node/public/elearn/worlds/calistung/shape/index.html
@@ -58,5 +58,6 @@
       try { const p = document.getElementById('hudPanel'); if (p) p.classList.remove('open'); } catch(_){ }
     }, 0);
   </script>
+  <script src="/elearn/common/worksheet-submit.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Calistung WhatsApp helper that enforces number capture, stores it, and sends worksheet results to the configured number
- expose stored WhatsApp numbers via getUserInfo and ensure Calistung world entry points load the helper script
- adjust Calistung navbar defaults so alphabet/number lessons link back to their maps and the portal
- expand lesson action button detection so auto-generated controls only appear when a lesson is missing them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62000ed848325bc5e8cfb823336b3